### PR TITLE
Fix type warning in run_tracker

### DIFF
--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -1059,7 +1059,7 @@ class TrackCleaner:
         connect_single_track_breaks(frames, self.instance_count)
 
 
-def run_tracker(frames: List[LabeledFrame], tracker: Tracker) -> List[LabeledFrame]:
+def run_tracker(frames: List[LabeledFrame], tracker: BaseTracker) -> List[LabeledFrame]:
     """Run a tracker on a set of labeled frames.
 
     Args:


### PR DESCRIPTION
run_tracker can accept a BaseTracker which is more generic than a Tracker.
I get a warning when doing this:

tracker = Tracker.make_tracker_by_name() # this returns a BaseTracker
frames = run_tracker(frames=frames, tracker=tracker) # Warning, run_tracker expects a "Tracker"