### PR TITLE
fix flow tracker failing at flow_shift_instances()

### DIFF
--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -186,15 +186,15 @@ class FlowCandidateMaker:
         if hasattr(new_img, "numpy"):
             new_img = new_img.numpy()
 
+        # Ensure images are rank 2 in case there is a singleton channel dimension.
+        if ref_img.ndim > 3:
+            ref_img = np.squeeze(ref_img)
+            new_img = np.squeeze(new_img)
+
         # Convert RGB to grayscale.
         if ref_img.ndim > 2 and ref_img.shape[-1] == 3:
             ref_img = cv2.cvtColor(ref_img, cv2.COLOR_BGR2GRAY)
             new_img = cv2.cvtColor(new_img, cv2.COLOR_BGR2GRAY)
-
-        # Ensure images are rank 2 in case there is a singleton channel dimension.
-        if ref_img.ndim > 2:
-            ref_img = np.squeeze(ref_img)
-            new_img = np.squeeze(new_img)
 
         # Input image scaling.
         if scale != 1:


### PR DESCRIPTION
`sleap-track --tracking.tracker flow ...` is failing with

```
Traceback (most recent call last):
  File "/home/matej/local/conda/envs/sleap_env/bin/sleap-track", line 33, in <module>
    sys.exit(load_entry_point('sleap', 'console_scripts', 'sleap-track')())
  File "/home/matej/prace/ferda/behavior/sleap/sleap/nn/inference.py", line 1309, in main
    video_predicted_frames = predictor.predict(video_reader)
  File "/home/matej/prace/ferda/behavior/sleap/sleap/nn/inference.py", line 227, in predict
    frames = run_tracker(tracker=self.tracker, frames=frames)
  File "/home/matej/prace/ferda/behavior/sleap/sleap/nn/tracking.py", line 1095, in run_tracker
    instances=tracker.track(**track_args),
  File "/home/matej/prace/ferda/behavior/sleap/sleap/nn/tracking.py", line 423, in track
    track_matching_queue=self.track_matching_queue, t=t, img=img,
  File "/home/matej/prace/ferda/behavior/sleap/sleap/nn/tracking.py", line 132, in get_candidates
    max_levels=self.of_max_levels,
  File "/home/matej/prace/ferda/behavior/sleap/sleap/nn/tracking.py", line 191, in flow_shift_instances
    ref_img = cv2.cvtColor(ref_img, cv2.COLOR_BGR2GRAY)
cv2.error: OpenCV(4.2.0) /io/opencv/modules/imgproc/src/color.simd_helpers.hpp:92: error: (-2:Unspecified error) in function 'cv::impl::{anonymous}::CvtHelper<VScn, VDcn, VDepth, sizePolicy>::CvtHelper(cv::InputArray, cv::OutputArray, int) [with VScn = cv::impl::{anonymous}::Set<3, 4>; VDcn = cv::impl::{anonymous}::Set<1>; VDepth = cv::impl::{anonymous}::Set<0, 2, 5>; cv::impl::{anonymous}::SizePolicy sizePolicy = (cv::impl::<unnamed>::SizePolicy)2u; cv::InputArray = const cv::_InputArray&; cv::OutputArray = const cv::_OutputArray&]'
> Invalid number of channels in input image:
>     'VScn::contains(scn)'
> where
>     'scn' is 1
```

that's because at https://github.com/murthylab/sleap/blob/3675f66f74004c660af66968cfdf7eac77e0beca/sleap/nn/tracking.py#L190

the images have shapes

```
(Pdb) ref_img.shape
(1, 1024, 1024, 3)
(Pdb) new_img.shape
(1, 1024, 1024, 3)
```
The patch squeezes the singelton dimension before `cv2.cvtColor`.
