### PR TITLE
Push old configs in the training UI to the end of the list

### DIFF
--- a/sleap/gui/learning/configs.py
+++ b/sleap/gui/learning/configs.py
@@ -383,6 +383,8 @@ class TrainingConfigsGetter:
                 configs_in_dir = self.find_configs_in_dir(dir, self.search_depth)
                 configs.extend(configs_in_dir)
 
+        configs.sort(key=lambda c: c.filename)
+
         return configs
 
     def get_filtered_configs(
@@ -459,9 +461,6 @@ class TrainingConfigsGetter:
         """Loads configs in specified directory."""
         # Find all json files in dir and subdirs to specified depth
         json_files = sleap_utils.find_files_by_suffix(dir, ".json", depth=depth)
-
-        # Sort files, starting with most recently modified
-        json_files.sort(key=lambda f: f.stat().st_mtime, reverse=True)
 
         # Get just the paths for the files we found
         json_paths = [file.path for file in json_files]

--- a/sleap/gui/learning/configs.py
+++ b/sleap/gui/learning/configs.py
@@ -57,9 +57,7 @@ class ConfigFileInfo:
 
     @property
     def path_dir(self):
-        if self.path.endswith("json"):
-            return os.path.dirname(self.path)
-        return self.path
+        return os.path.dirname(self.path) if self.path.endswith("json") else self.path
 
     def _get_file_path(self, shortname) -> Optional[Text]:
         """
@@ -73,9 +71,7 @@ class ConfigFileInfo:
         if not self.config.outputs.run_name:
             return None
 
-        dirs_to_try = [self.config.outputs.run_path, self.path_dir]
-
-        for dir in dirs_to_try:
+        for dir in [self.config.outputs.run_path, self.path_dir]:
             full_path = os.path.join(dir, shortname)
             if os.path.exists(full_path):
                 return full_path
@@ -161,9 +157,7 @@ class ConfigFileInfo:
             return None
 
         with np.load(metrics_path, allow_pickle=True) as data:
-            metrics = data["metrics"].item()
-
-        return metrics
+            return data["metrics"].item()
 
     @classmethod
     def from_config_file(cls, path: Text) -> "ConfigFileInfo":
@@ -253,20 +247,9 @@ class TrainingConfigFilesWidget(FieldComboWidget):
 
         self.set_options(option_list, select_item=select_key)
 
-    # def selectByIdx(self, option_idx: int):
-    #     self.setCurrentIndex(option_idx)
-    #     self.onSelectionIdxChange(option_idx)
-    #
-    # def lastOptionIdx(self):
-    #     return self.count()
-
     @property
     def _menu_cfg_idx_offset(self):
-        if not hasattr(self, "options_list"):
-            return 0
-        if not self.options_list:
-            return 0
-        if self.options_list[0] == "":
+        if hasattr(self, "options_list") and self.options_list and self.options_list[0] == "":
             return 1
         return 0
 
@@ -279,8 +262,7 @@ class TrainingConfigFilesWidget(FieldComboWidget):
         """
         Return currently selected `ConfigFileInfo` (if any, None otherwise).
         """
-        current_idx = self.currentIndex()
-        return self.getConfigInfoByMenuIdx(current_idx)
+        return self.getConfigInfoByMenuIdx(self.currentIndex())
 
     def onSelectionIdxChange(self, menu_idx: int):
         """
@@ -314,11 +296,7 @@ class TrainingConfigFilesWidget(FieldComboWidget):
             caption="Select training configuration file...",
             filter="JSON (*.json)",
         )
-
-        if not filename:
-            return None
-
-        return self._cfg_getter.try_loading_path(filename)
+        return self._cfg_getter.try_loading_path(filename) if filename else None
 
     def _add_file_selection_to_menu(self, cfg_info: Optional[ConfigFileInfo] = None):
         if cfg_info:
@@ -423,17 +401,11 @@ class TrainingConfigsGetter:
 
     def get_first(self) -> Optional[ConfigFileInfo]:
         """Get first loaded config."""
-        if self._configs:
-            return self._configs[0]
-        return None
+        return self._configs[0] if self._configs else None
 
     def insert_first(self, cfg_info: ConfigFileInfo):
         """Insert config at beginning of list."""
         self._configs.insert(0, cfg_info)
-
-    def insert_last(self, cfg_info: ConfigFileInfo):
-        """Insert config at end of list."""
-        self._configs.append(cfg_info)
 
     def try_loading_path(self, path: Text) -> Optional[ConfigFileInfo]:
         """Attempts to load config file and wrap in `ConfigFileInfo` object."""

--- a/sleap/gui/learning/configs.py
+++ b/sleap/gui/learning/configs.py
@@ -382,9 +382,9 @@ class TrainingConfigsGetter:
             if os.path.exists(dir):
                 configs_in_dir = self.find_configs_in_dir(dir, self.search_depth)
                 configs.extend(configs_in_dir)
-
+        
+        # Sort configs by filename
         configs.sort(key=lambda c: c.filename)
-
         return configs
 
     def get_filtered_configs(

--- a/sleap/gui/learning/configs.py
+++ b/sleap/gui/learning/configs.py
@@ -382,7 +382,7 @@ class TrainingConfigsGetter:
             if os.path.exists(dir):
                 configs_in_dir = self.find_configs_in_dir(dir, self.search_depth)
                 configs.extend(configs_in_dir)
-        
+
         # Sort configs by filename
         configs.sort(key=lambda c: c.filename)
         return configs

--- a/tests/gui/test_inference_gui.py
+++ b/tests/gui/test_inference_gui.py
@@ -16,8 +16,11 @@ def test_config_list_load():
 
 def test_config_list_order():
     configs = TrainingConfigsGetter.make_from_labels_filename("").get_filtered_configs()
-    config_names = [s.filename for s in configs]
-    assert sorted(config_names) == config_names
+
+    # Check that all 'old' configs (if any) are last in the collected configs list
+    for i in range(len(configs) - 1):
+        # if current config is 'old', next must be 'old' as well
+        assert not configs[i].filename.startswith('old.') or configs[i + 1].filename.startswith('old.')
 
 def test_scoped_key_dict():
     d = {"foo": 1, "bar": {"cat": {"dog": 2}, "elephant": 3}}

--- a/tests/gui/test_inference_gui.py
+++ b/tests/gui/test_inference_gui.py
@@ -14,6 +14,11 @@ def test_config_list_load():
     assert 2 == len(configs)
 
 
+def test_config_list_order():
+    configs = TrainingConfigsGetter.make_from_labels_filename("").get_filtered_configs()
+    config_names = [s.filename for s in configs]
+    assert sorted(config_names) == config_names
+
 def test_scoped_key_dict():
     d = {"foo": 1, "bar": {"cat": {"dog": 2}, "elephant": 3}}
 


### PR DESCRIPTION
+ Small refactor to have all 'config sorting' logic in one place
+ Minor cleanup of code while reading the configs.py module 