### PR TITLE
Fix CPU thrashing

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -220,10 +220,10 @@ class MainWindow(QMainWindow):
 
         self._load_overlays()
 
-        # Create timer to update state of gui at regular intervals
+        # Create timer to update state of gui at 20 millisec. intervals
         self.update_gui_timer = QtCore.QTimer()
         self.update_gui_timer.timeout.connect(self._update_gui_state)
-        self.update_gui_timer.start(1)
+        self.update_gui_timer.start(20)
 
     def _create_video_player(self):
         """Creates and connects :class:`QtVideoPlayer` for gui."""
@@ -1545,6 +1545,13 @@ def main():
         const=True,
         default=False,
     )
+    parser.add_argument(
+        "--profiling",
+        help="Enable performance profiling",
+        action="store_const",
+        const=True,
+        default=False,
+    )
 
     args = parser.parse_args()
 
@@ -1560,7 +1567,11 @@ def main():
     # if not args.labels_path:
     #     window.commands.openProject(first_open=True)
 
-    app.exec_()
+    if args.profiling:
+        import cProfile
+        cProfile.runctx('app.exec_()', globals=globals(), locals=locals())
+    else:
+        app.exec_()
 
 
 if __name__ == "__main__":

--- a/sleap/gui/widgets/video.py
+++ b/sleap/gui/widgets/video.py
@@ -107,10 +107,10 @@ class LoadImageWorker(QtCore.QObject):
         # event to event queue from the request handler.
         self.process.connect(self.doProcessing)
 
-        # Start timer which will trigger processing events when we're free
+        # Start timer which will trigger processing events every 20 msec. when we're free
         self.timer = QtCore.QTimer()
         self.timer.timeout.connect(self.doProcessing)
-        self.timer.start(0)
+        self.timer.start(20)
 
     def doProcessing(self):
         self._last_process_time = time.time()

--- a/sleap/nn/monitor.py
+++ b/sleap/nn/monitor.py
@@ -236,10 +236,10 @@ class LossViewer(QtWidgets.QMainWindow):
             self.zmq_ctrl = self.ctx.socket(zmq.PUB)
             self.zmq_ctrl.bind("tcp://127.0.0.1:9000")
 
-        # Set timer to poll for messages
+        # Set timer to poll for messages every 20 milliseconds
         self.timer = QtCore.QTimer()
         self.timer.timeout.connect(self.check_messages)
-        self.timer.start(0)
+        self.timer.start(20)
 
     def stop(self):
         """Action to stop training."""
@@ -423,7 +423,7 @@ if __name__ == "__main__":
 
     t = QtCore.QTimer()
     t.timeout.connect(test_point)
-    t.start(0)
+    t.start(20)
 
     win.set_message("Waiting for 3 seconds...")
     t2 = QtCore.QTimer()


### PR DESCRIPTION
On my 5 year old MacBook PRO CPU is constantly at >100% when sleap-label is running (even in idle mode).
- Ran profiler and found that multiple threads were running checks in busy loops (using timer)
- Set all timers to run with 20 milisec intervals (50 Hz)
Now CPU usage down to 0% when idle