### PR TITLE
Pretrained encoder backbone

### DIFF
--- a/.conda/bld.bat
+++ b/.conda/bld.bat
@@ -37,6 +37,7 @@ pip install qimage2ndarray==1.8
 pip install jsmin
 pip install seaborn
 pip install pykalman==0.9.5
+pip install segmentation-models==1.0.1
 
 rem # Use and update environment.yml call to install pip dependencies. This is slick.
 rem # While environment.yml contains the non pip dependencies, the only thing left

--- a/.conda/build.sh
+++ b/.conda/build.sh
@@ -35,6 +35,7 @@ pip install qimage2ndarray==1.8
 pip install jsmin
 pip install seaborn
 pip install pykalman==0.9.5
+pip install segmentation-models==1.0.1
 
 pip install setuptools-scm
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ qimage2ndarray==1.8
 jsmin
 seaborn
 pykalman==0.9.5
+segmentation-models==1.0.1

--- a/sleap/config/training_editor_form.yaml
+++ b/sleap/config/training_editor_form.yaml
@@ -21,8 +21,15 @@ data:
   type: optional_int
   none_label: Auto
   range: 0,512
+
 model:
 - default: unet
+  label: Backbone
+  name: _backbone_name
+  options: leap,unet,hourglass,resnet,pretrained_encoder
+  type: stacked
+
+#####
   hourglass:
   - default: 4
     help: Controls how many stem blocks to use for initial downsampling. These are
@@ -64,7 +71,9 @@ model:
     label: Stacks
     name: model.backbone.hourglass.stacks
     type: int
-  label: Backbone
+#####
+
+#####
   leap:
   - default: 8
     help: Determines the number of downsampling blocks in the network, increasing
@@ -100,8 +109,9 @@ model:
   #   label: Stacks
   #   name: model.backbone.leap.stacks
   #   type: int
-  name: _backbone_name
-  options: leap,unet,hourglass,resnet
+#####
+
+#####
   resnet:
   - default: ResNet50
     help: 'Name of the ResNetV1 variant. Can be one of: "ResNet50", "ResNet101", or
@@ -189,7 +199,43 @@ model:
   #   name: model.backbone.resnet.output_stride
   #   type: list
   #   options: 1,2,4,8,16,32,64
-  type: stacked
+#####
+
+#####
+#####
+  pretrained_encoder:
+  - label: Encoder
+    name: model.backbone.pretrained_encoder.encoder
+    default: efficientnetb0
+    help: 'Name of the network architecture to use as the encoder.'
+    options: vgg16,vgg19,resnet18,resnet34,resnet50,resnet101,resnet152,resnext50,resnext101,inceptionv3,inceptionresnetv2,densenet121,densenet169,densenet201,seresnet18,seresnet34,seresnet50,seresnet101,seresnet152,seresnext50,seresnext101,senet154,mobilenet,mobilenetv2,efficientnetb0,efficientnetb1,efficientnetb2,efficientnetb3,efficientnetb4,efficientnetb5,efficientnetb6,efficientnetb7
+    type: list
+  - label: Pretrained
+    name: model.backbone.pretrained_encoder.pretrained
+    default: true
+    help: Use ImageNet-pretrained weights for initialization (transfer learning). Model
+      will have randomly initialized weights otherwise.
+    type: bool
+  - label: Decoder filters
+    name: model.backbone.pretrained_encoder.decoder_filters
+    default: 256
+    help: Base number of filters for the upsampling blocks in the decoder.
+    type: int
+  - label: Decoder filters rate
+    name: model.backbone.pretrained_encoder.decoder_filters_rate
+    default: 1.0
+    help: Factor to scale the number of filters by at each consecutive upsampling block
+      in the decoder.
+    type: double
+  # - label: Output Stride
+  #   name: model.backbone.pretrained_encoder.output_stride
+  #   help: Determines the number of upsampling blocks in the network.
+  #   type: list
+  #   options: 1,2,4,8,16
+  #   default: 2
+#####
+
+#####
   unet:
   - default: null
     help: If not None, controls how many stem blocks to use for initial downsampling.
@@ -239,6 +285,8 @@ model:
   #   label: Stacks
   #   name: model.backbone.unet.stacks
   #   type: int
+#####
+
 - centered_instance:
   - default: null
     help: Text name of a body part (node) to use as the anchor point. If None, the

--- a/sleap/gui/learning/scopedkeydict.py
+++ b/sleap/gui/learning/scopedkeydict.py
@@ -140,6 +140,7 @@ def resolve_strides_from_key_val_dict(
     )
 
     for key in [
+        "model.heads.single_instance.output_stride",
         "model.heads.centered_instance.output_stride",
         "model.heads.centroid.output_stride",
         "model.heads.multi_instance.confmaps.output_stride",

--- a/sleap/nn/architectures/__init__.py
+++ b/sleap/nn/architectures/__init__.py
@@ -4,9 +4,11 @@ from sleap.nn.architectures import hourglass
 from sleap.nn.architectures import resnet
 from sleap.nn.architectures import common
 from sleap.nn.architectures import upsampling
+from sleap.nn.architectures import pretrained_encoders
 
 from sleap.nn.architectures.leap import LeapCNN
 from sleap.nn.architectures.unet import UNet
 from sleap.nn.architectures.hourglass import Hourglass
 from sleap.nn.architectures.resnet import ResNetv1, ResNet50, ResNet101, ResNet152
 from sleap.nn.architectures.common import IntermediateFeature
+from sleap.nn.architectures.pretrained_encoders import UnetPretrainedEncoder

--- a/sleap/nn/architectures/pretrained_encoders.py
+++ b/sleap/nn/architectures/pretrained_encoders.py
@@ -45,7 +45,7 @@ from typing import Tuple, List
 
 from sleap.nn.architectures.upsampling import IntermediateFeature
 from sleap.nn.data.normalization import ensure_rgb
-from sleap.nn.config import UnetPretrainedEncoderConfig
+from sleap.nn.config import PretrainedEncoderConfig
 
 import os
 
@@ -139,12 +139,12 @@ class UnetPretrainedEncoder:
 
     @classmethod
     def from_config(
-        cls, config: UnetPretrainedEncoderConfig
+        cls, config: PretrainedEncoderConfig
     ) -> "UnetPretrainedEncoder":
         """Create the backbone from a configuration.
 
         Args:
-            config: A `UnetPretrainedEncoderConfig` instance specifying the
+            config: A `PretrainedEncoderConfig` instance specifying the
                 configuration of the backbone.
 
         Returns:

--- a/sleap/nn/architectures/pretrained_encoders.py
+++ b/sleap/nn/architectures/pretrained_encoders.py
@@ -1,0 +1,242 @@
+"""Encoder-decoder backbones with pretrained encoder models.
+
+This module enables encoder-decoder style architectures using a wide range of
+state-of-the-art architectures as the encoder, with a UNet-like upsampling stack that
+also takes advantage of skip connections from the encoder blocks. Additionally, the
+encoder models can use ImageNet-pretrained weights for initialization.
+
+This module is made possible by the work by Pavel Yakubovskiy who graciously put
+together a library implementing common pretrained fully-convolutional architectures and
+their weights.
+
+For more info, see the source repositories:
+    - https://github.com/qubvel/segmentation_models
+    - https://github.com/qubvel/classification_models
+
+License:
+
+The MIT License
+
+Copyright (c) 2018, Pavel Yakubovskiy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+import tensorflow as tf
+import numpy as np
+import attr
+from typing import Tuple, List
+
+from sleap.nn.architectures.upsampling import IntermediateFeature
+from sleap.nn.data.normalization import ensure_rgb
+from sleap.nn.config import UnetPretrainedEncoderConfig
+
+import os
+
+os.environ["SM_FRAMEWORK"] = "tf.keras"
+import io
+from contextlib import redirect_stdout
+
+with redirect_stdout(io.StringIO()):
+    # Import segmentation_models suppressing output to stdout about backend.
+    import segmentation_models as sm
+
+
+AVAILABLE_ENCODERS = [
+    "vgg16",
+    "vgg19",
+    "resnet18",
+    "resnet34",
+    "resnet50",
+    "resnet101",
+    "resnet152",
+    "resnext50",
+    "resnext101",
+    "inceptionv3",
+    "inceptionresnetv2",
+    "densenet121",
+    "densenet169",
+    "densenet201",
+    "seresnet18",
+    "seresnet34",
+    "seresnet50",
+    "seresnet101",
+    "seresnet152",
+    "seresnext50",
+    "seresnext101",
+    "senet154",
+    "mobilenet",
+    "mobilenetv2",
+    "efficientnetb0",
+    "efficientnetb1",
+    "efficientnetb2",
+    "efficientnetb3",
+    "efficientnetb4",
+    "efficientnetb5",
+    "efficientnetb6",
+    "efficientnetb7",
+]
+
+
+@attr.s(auto_attribs=True)
+class UnetPretrainedEncoder:
+    """UNet with an (optionally) pretrained encoder model.
+
+    This backbone enables the use of a variety of popular neural network architectures
+    for feature extraction in the backbone. These can be used with ImageNet-pretrained
+    weights for initialization. The decoder (upsampling stack) receives skip connections
+    from intermediate activations in the encoder blocks.
+
+    All of the encoder models have a maximum stride of 32 and the input does not need to
+    be preprocessed in any special way. Grayscale images will be tiled to have 3
+    channels automatically.
+
+    See https://github.com/qubvel/classification_models#specification for more
+    information on the individual backbones.
+
+    Attributes:
+        encoder: Name of the model to use as the encoder. Valid encoder names are:
+            - `"vgg16", "vgg19",`
+            - `"resnet18", "resnet34", "resnet50", "resnet101", "resnet152"`
+            - `"resnext50", "resnext101"`
+            - `"inceptionv3", "inceptionresnetv2"`
+            - `"densenet121", "densenet169", "densenet201"`
+            - `"seresnet18", "seresnet34", "seresnet50", "seresnet101", "seresnet152",`
+              `"seresnext50", "seresnext101", "senet154"`
+            - `"mobilenet", "mobilenetv2"`
+            - `"efficientnetb0", "efficientnetb1", "efficientnetb2", "efficientnetb3",`
+              `"efficientnetb4", "efficientnetb5", "efficientnetb6", "efficientnetb7"`
+            Defaults to `"mobilenetv2"`
+        decoder_filters: A tuple of integers denoting the number of filters to use in
+            the upsampling blocks of the decoder, starting from the lowest resolution
+            block. The length of this attribute also specifies the number of upsampling
+            steps and therefore the output stride of the backbone. Specify 5 filter
+            numbers to get an output stride of 1 (same size as the input). Defaults to
+        pretrained: If `True` (the default), load pretrained weights for the encoder. If
+            `False`, the same model architecture will be used for the encoder but the
+            weights will be randomly initialized.
+    """
+
+    encoder: str = attr.ib(default="mobilenetv2", validator=attr.validators.in_(AVAILABLE_ENCODERS))
+    decoder_filters: Tuple[int] = (256, 256, 128, 128)
+    pretrained: bool = True
+
+    @classmethod
+    def from_config(
+        cls, config: UnetPretrainedEncoderConfig
+    ) -> "UnetPretrainedEncoder":
+        """Create the backbone from a configuration.
+
+        Args:
+            config: A `UnetPretrainedEncoderConfig` instance specifying the
+                configuration of the backbone.
+
+        Returns:
+            An instantiated `UnetPretrainedEncoder`.
+        """
+        up_blocks = int(np.log2(32 // config.output_stride))
+        decoder_filters = [
+            int(config.decoder_filters * (config.decoder_filters_rate ** i))
+            for i in range(up_blocks)
+        ]
+
+        return cls(
+            encoder=config.encoder,
+            pretrained=config.pretrained,
+            decoder_filters=tuple(decoder_filters),
+        )
+
+    @property
+    def down_blocks(self) -> int:
+        """Return the number of downsampling blocks in the encoder."""
+        return 5
+
+    @property
+    def up_blocks(self) -> int:
+        """Return the number of upsampling blocks in the decoder."""
+        return len(self.decoder_filters)
+
+    @property
+    def maximum_stride(self) -> int:
+        """Return the maximum encoder stride relative to the input."""
+        return 32
+
+    @property
+    def output_stride(self) -> int:
+        """Return the stride of the output of the decoder."""
+        return int(2 ** (self.down_blocks - self.up_blocks))
+
+    def make_backbone(
+        self, x_in: tf.Tensor
+    ) -> Tuple[tf.Tensor, List[IntermediateFeature]]:
+        """Create the backbone and return the output tensors for building a model.
+
+        Args:
+            x_in: A `tf.Tensor` representing the input to this backbone. This is
+                typically an instance of `tf.keras.layers.Input()` but can also be any
+                rank-4 tensor. Can be grayscale or RGB.
+
+        Returns:
+            A tuple of (`x_main`, `intermediate_activations`).
+
+            `x_main` is the output tensor from the last upsampling block.
+
+            `intermediate_activations` is a list of `IntermediateActivation`s containing
+            tensors with the outputs from each block of the decoder for use in building
+            multi-output models at different feature strides.
+        """
+        img_shape = x_in.shape[1:]
+
+        if self.pretrained and img_shape[-1] == 1:
+            # Add preprocessing layer if needed.
+            x_in = tf.keras.layers.Lambda(lambda x: ensure_rgb(x), name="ensure_rgb")(
+                x_in
+            )
+            img_shape = (img_shape[0], img_shape[1], 3)
+
+        # Create base model.
+        base_model = sm.models.unet.Unet(
+            backbone_name=self.encoder,
+            input_shape=img_shape,
+            classes=1,
+            activation="linear",
+            encoder_weights="imagenet" if self.pretrained else None,
+            decoder_block_type="upsampling",
+            decoder_filters=self.decoder_filters,
+            decoder_use_batchnorm=True,
+            layers=tf.keras.layers,
+            models=tf.keras.models,
+            backend=tf.keras.backend,
+            utils=tf.keras.utils,
+        )
+        backbone_model = base_model(x_in)
+
+        # Collect intermediate features from the decoder.
+        intermediate_features = []
+        for i in range(self.up_blocks):
+            intermediate_features.append(
+                IntermediateFeature(
+                    tensor=base_model.get_layer(f"decoder_stage{i}b_relu").output,
+                    stride=2 ** (4 - i),
+                )
+            )
+
+        output = intermediate_features[-1].tensor
+
+        return output, intermediate_features

--- a/sleap/nn/config/__init__.py
+++ b/sleap/nn/config/__init__.py
@@ -17,6 +17,7 @@ from sleap.nn.config.model import (
     HourglassConfig,
     UpsamplingConfig,
     ResNetConfig,
+    UnetPretrainedEncoderConfig,
     BackboneConfig,
     ModelConfig,
 )

--- a/sleap/nn/config/__init__.py
+++ b/sleap/nn/config/__init__.py
@@ -17,7 +17,7 @@ from sleap.nn.config.model import (
     HourglassConfig,
     UpsamplingConfig,
     ResNetConfig,
-    UnetPretrainedEncoderConfig,
+    PretrainedEncoderConfig,
     BackboneConfig,
     ModelConfig,
 )

--- a/sleap/nn/config/model.py
+++ b/sleap/nn/config/model.py
@@ -422,6 +422,27 @@ class ResNetConfig:
     output_stride: int = 4
 
 
+@attr.s(auto_attribs=True)
+class UnetPretrainedEncoderConfig:
+    """Configuration for UNet backbone with pretrained encoder.
+
+    Attributes:
+        encoder: Name of the network architecture to use as the encoder.
+        pretrained: If `True`, use initialized with weights pretrained on ImageNet.
+        decoder_filters: Base number of filters for the upsampling blocks in the
+            decoder.
+        decoder_filters_rate: Factor to scale the number of filters by at each
+            consecutive upsampling block in the decoder.
+        output_stride: Stride of the final output.
+    """
+
+    encoder: Text = attr.ib(default="mobilenetv2")
+    pretrained: bool = True
+    decoder_filters: int = 256
+    decoder_filters_rate: float = 1.0
+    output_stride: int = 2
+
+
 @oneof
 @attr.s(auto_attribs=True)
 class BackboneConfig:

--- a/sleap/nn/config/model.py
+++ b/sleap/nn/config/model.py
@@ -436,7 +436,7 @@ class PretrainedEncoderConfig:
         output_stride: Stride of the final output.
     """
 
-    encoder: Text = attr.ib(default="mobilenetv2")
+    encoder: Text = attr.ib(default="efficientnetb0")
     pretrained: bool = True
     decoder_filters: int = 256
     decoder_filters_rate: float = 1.0

--- a/sleap/nn/config/model.py
+++ b/sleap/nn/config/model.py
@@ -423,7 +423,7 @@ class ResNetConfig:
 
 
 @attr.s(auto_attribs=True)
-class UnetPretrainedEncoderConfig:
+class PretrainedEncoderConfig:
     """Configuration for UNet backbone with pretrained encoder.
 
     Attributes:
@@ -461,6 +461,7 @@ class BackboneConfig:
     unet: Optional[UNetConfig] = None
     hourglass: Optional[HourglassConfig] = None
     resnet: Optional[ResNetConfig] = None
+    pretrained_encoder: Optional[PretrainedEncoderConfig] = None
 
 
 @attr.s(auto_attribs=True)

--- a/sleap/nn/model.py
+++ b/sleap/nn/model.py
@@ -18,6 +18,7 @@ from sleap.nn.architectures import (
     ResNet50,
     ResNet101,
     ResNet152,
+    UnetPretrainedEncoder,
     IntermediateFeature,
 )
 from sleap.nn.heads import (
@@ -32,6 +33,7 @@ from sleap.nn.config import (
     UNetConfig,
     HourglassConfig,
     ResNetConfig,
+    UnetPretrainedEncoderConfig,
     SingleInstanceConfmapsHeadConfig,
     CentroidsHeadConfig,
     CenteredInstanceConfmapsHeadConfig,
@@ -43,7 +45,16 @@ from sleap.nn.config import (
 from sleap.nn.data.utils import ensure_list
 
 
-ARCHITECTURES = [LeapCNN, UNet, Hourglass, ResNetv1, ResNet50, ResNet101, ResNet152]
+ARCHITECTURES = [
+    LeapCNN,
+    UNet,
+    Hourglass,
+    ResNetv1,
+    ResNet50,
+    ResNet101,
+    ResNet152,
+    UnetPretrainedEncoder,
+]
 ARCHITECTURE_NAMES = [cls.__name__ for cls in ARCHITECTURES]
 Architecture = TypeVar("Architecture", *ARCHITECTURES)
 
@@ -52,6 +63,7 @@ BACKBONE_CONFIG_TO_CLS = {
     UNetConfig: UNet,
     HourglassConfig: Hourglass,
     ResNetConfig: ResNetv1,
+    UnetPretrainedEncoderConfig: UnetPretrainedEncoder,
 }
 
 HEADS = [

--- a/sleap/nn/model.py
+++ b/sleap/nn/model.py
@@ -33,7 +33,7 @@ from sleap.nn.config import (
     UNetConfig,
     HourglassConfig,
     ResNetConfig,
-    UnetPretrainedEncoderConfig,
+    PretrainedEncoderConfig,
     SingleInstanceConfmapsHeadConfig,
     CentroidsHeadConfig,
     CenteredInstanceConfmapsHeadConfig,
@@ -63,7 +63,7 @@ BACKBONE_CONFIG_TO_CLS = {
     UNetConfig: UNet,
     HourglassConfig: Hourglass,
     ResNetConfig: ResNetv1,
-    UnetPretrainedEncoderConfig: UnetPretrainedEncoder,
+    PretrainedEncoderConfig: UnetPretrainedEncoder,
 }
 
 HEADS = [

--- a/sleap/training_profiles/baseline.centroid.json
+++ b/sleap/training_profiles/baseline.centroid.json
@@ -35,7 +35,8 @@
                 "stacks": 1
             },
             "hourglass": null,
-            "resnet": null
+            "resnet": null,
+            "pretrained_encoder": null
         },
         "heads": {
             "single_instance": null,

--- a/sleap/training_profiles/baseline_large_rf.bottomup.json
+++ b/sleap/training_profiles/baseline_large_rf.bottomup.json
@@ -35,7 +35,8 @@
                 "stacks": 1
             },
             "hourglass": null,
-            "resnet": null
+            "resnet": null,
+            "pretrained_encoder": null
         },
         "heads": {
             "single_instance": null,
@@ -44,13 +45,13 @@
             "multi_instance": {
                 "confmaps": {
                     "part_names": null,
-                    "sigma": 5.0,
+                    "sigma": 2.5,
                     "output_stride": 4,
-                    "loss_weight": 5.0
+                    "loss_weight": 1.0
                 },
                 "pafs": {
                     "edges": null,
-                    "sigma": 50.0,
+                    "sigma": 75.0,
                     "output_stride": 8,
                     "loss_weight": 1.0
                 }

--- a/sleap/training_profiles/baseline_large_rf.topdown.json
+++ b/sleap/training_profiles/baseline_large_rf.topdown.json
@@ -35,7 +35,8 @@
                 "stacks": 1
             },
             "hourglass": null,
-            "resnet": null
+            "resnet": null,
+            "pretrained_encoder": null
         },
         "heads": {
             "single_instance": null,

--- a/sleap/training_profiles/baseline_medium_rf.bottomup.json
+++ b/sleap/training_profiles/baseline_medium_rf.bottomup.json
@@ -35,7 +35,8 @@
                 "stacks": 1
             },
             "hourglass": null,
-            "resnet": null
+            "resnet": null,
+            "pretrained_encoder": null
         },
         "heads": {
             "single_instance": null,
@@ -44,13 +45,13 @@
             "multi_instance": {
                 "confmaps": {
                     "part_names": null,
-                    "sigma": 5.0,
+                    "sigma": 2.5,
                     "output_stride": 4,
-                    "loss_weight": 5.0
+                    "loss_weight": 1.0
                 },
                 "pafs": {
                     "edges": null,
-                    "sigma": 50.0,
+                    "sigma": 75.0,
                     "output_stride": 8,
                     "loss_weight": 1.0
                 }

--- a/sleap/training_profiles/baseline_medium_rf.single.json
+++ b/sleap/training_profiles/baseline_medium_rf.single.json
@@ -35,7 +35,8 @@
                 "stacks": 1
             },
             "hourglass": null,
-            "resnet": null
+            "resnet": null,
+            "pretrained_encoder": null
         },
         "heads": {
             "single_instance": {

--- a/sleap/training_profiles/baseline_medium_rf.topdown.json
+++ b/sleap/training_profiles/baseline_medium_rf.topdown.json
@@ -35,7 +35,8 @@
                 "stacks": 1
             },
             "hourglass": null,
-            "resnet": null
+            "resnet": null,
+            "pretrained_encoder": null
         },
         "heads": {
             "single_instance": null,

--- a/sleap/training_profiles/pretrained.bottomup.json
+++ b/sleap/training_profiles/pretrained.bottomup.json
@@ -90,7 +90,7 @@
         "min_val_batches_per_epoch": 10,
         "epochs": 200,
         "optimizer": "adam",
-        "initial_learning_rate": 0.0001,
+        "initial_learning_rate": 0.001,
         "learning_rate_schedule": {
             "reduce_on_plateau": true,
             "reduction_factor": 0.5,

--- a/sleap/training_profiles/pretrained.bottomup.json
+++ b/sleap/training_profiles/pretrained.bottomup.json
@@ -28,23 +28,31 @@
             "hourglass": null,
             "resnet": null,
             "pretrained_encoder": {
-                "encoder": "mobilenetv2",
+                "encoder": "efficientnetb0",
                 "pretrained": true,
                 "decoder_filters": 256,
                 "decoder_filters_rate": 1.0,
-                "output_stride": 2
+                "output_stride": 4
             }
         },
         "heads": {
             "single_instance": null,
             "centroid": null,
-            "centered_instance": {
-                "anchor_part": null,
-                "part_names": null,
-                "sigma": 1.5,
-                "output_stride": 2
-            },
-            "multi_instance": null
+            "centered_instance": null,
+            "multi_instance": {
+                "confmaps": {
+                    "part_names": null,
+                    "sigma": 5.0,
+                    "output_stride": 4,
+                    "loss_weight": 1.0
+                },
+                "pafs": {
+                    "edges": null,
+                    "sigma": 75.0,
+                    "output_stride": 8,
+                    "loss_weight": 1.0
+                }
+            }
         }
     },
     "optimization": {
@@ -86,8 +94,8 @@
         "learning_rate_schedule": {
             "reduce_on_plateau": true,
             "reduction_factor": 0.5,
-            "plateau_min_delta": 1e-08,
-            "plateau_patience": 5,
+            "plateau_min_delta": 1e-06,
+            "plateau_patience": 8,
             "plateau_cooldown": 3,
             "min_learning_rate": 1e-08
         },
@@ -100,13 +108,13 @@
         },
         "early_stopping": {
             "stop_training_on_plateau": true,
-            "plateau_min_delta": 1e-08,
+            "plateau_min_delta": 1e-06,
             "plateau_patience": 10
         }
     },
     "outputs": {
         "save_outputs": true,
-        "run_name": "pretrained_mobilenetv2.topdown",
+        "run_name": "pretrained.bottomup",
         "run_name_prefix": "",
         "run_name_suffix": null,
         "runs_folder": "models",
@@ -123,7 +131,7 @@
         "tensorboard": {
             "write_logs": false,
             "loss_frequency": "epoch",
-            "architecture_graph": true,
+            "architecture_graph": false,
             "profile_graph": false,
             "visualizations": true
         },

--- a/sleap/training_profiles/pretrained.centroid.json
+++ b/sleap/training_profiles/pretrained.centroid.json
@@ -81,7 +81,7 @@
         "min_val_batches_per_epoch": 10,
         "epochs": 200,
         "optimizer": "adam",
-        "initial_learning_rate": 0.0001,
+        "initial_learning_rate": 0.001,
         "learning_rate_schedule": {
             "reduce_on_plateau": true,
             "reduction_factor": 0.5,

--- a/sleap/training_profiles/pretrained.centroid.json
+++ b/sleap/training_profiles/pretrained.centroid.json
@@ -12,7 +12,7 @@
             "ensure_rgb": false,
             "ensure_grayscale": false,
             "imagenet_mode": null,
-            "input_scaling": 1.0,
+            "input_scaling": 0.5,
             "pad_to_stride": null
         },
         "instance_cropping": {
@@ -24,27 +24,24 @@
     "model": {
         "backbone": {
             "leap": null,
-            "unet": {
-                "stem_stride": null,
-                "max_stride": 32,
-                "output_stride": 4,
-                "filters": 32,
-                "filters_rate": 1.5,
-                "middle_block": true,
-                "up_interpolate": true,
-                "stacks": 1
-            },
+            "unet": null,
             "hourglass": null,
             "resnet": null,
-            "pretrained_encoder": null
+            "pretrained_encoder": {
+                "encoder": "efficientnetb0",
+                "pretrained": true,
+                "decoder_filters": 128,
+                "decoder_filters_rate": 1.0,
+                "output_stride": 2
+            }
         },
         "heads": {
-            "single_instance": {
-                "part_names": null,
-                "sigma": 5,
-                "output_stride": 4
+            "single_instance": null,
+            "centroid": {
+                "anchor_part": null,
+                "sigma": 5.0,
+                "output_stride": 2
             },
-            "centroid": null,
             "centered_instance": null,
             "multi_instance": null
         }
@@ -81,14 +78,14 @@
         "batches_per_epoch": null,
         "min_batches_per_epoch": 200,
         "val_batches_per_epoch": null,
-        "min_val_batches_per_epoch": 20,
+        "min_val_batches_per_epoch": 10,
         "epochs": 200,
         "optimizer": "adam",
         "initial_learning_rate": 0.0001,
         "learning_rate_schedule": {
             "reduce_on_plateau": true,
             "reduction_factor": 0.5,
-            "plateau_min_delta": 1e-05,
+            "plateau_min_delta": 1e-06,
             "plateau_patience": 5,
             "plateau_cooldown": 3,
             "min_learning_rate": 1e-08
@@ -108,7 +105,7 @@
     },
     "outputs": {
         "save_outputs": true,
-        "run_name": "baseline_large_rf.single",
+        "run_name": "pretrained.centroid",
         "run_name_prefix": "",
         "run_name_suffix": null,
         "runs_folder": "models",

--- a/sleap/training_profiles/pretrained.single.json
+++ b/sleap/training_profiles/pretrained.single.json
@@ -81,7 +81,7 @@
         "min_val_batches_per_epoch": 20,
         "epochs": 200,
         "optimizer": "adam",
-        "initial_learning_rate": 0.0001,
+        "initial_learning_rate": 0.001,
         "learning_rate_schedule": {
             "reduce_on_plateau": true,
             "reduction_factor": 0.5,

--- a/sleap/training_profiles/pretrained.single.json
+++ b/sleap/training_profiles/pretrained.single.json
@@ -36,14 +36,13 @@
             }
         },
         "heads": {
-            "single_instance": null,
-            "centroid": null,
-            "centered_instance": {
-                "anchor_part": null,
+            "single_instance": {
                 "part_names": null,
-                "sigma": 1.5,
-                "output_stride": 2
+                "sigma": 2.5,
+                "output_stride": 4
             },
+            "centroid": null,
+            "centered_instance": null,
             "multi_instance": null
         }
     },
@@ -79,14 +78,14 @@
         "batches_per_epoch": null,
         "min_batches_per_epoch": 200,
         "val_batches_per_epoch": null,
-        "min_val_batches_per_epoch": 10,
+        "min_val_batches_per_epoch": 20,
         "epochs": 200,
         "optimizer": "adam",
         "initial_learning_rate": 0.0001,
         "learning_rate_schedule": {
             "reduce_on_plateau": true,
             "reduction_factor": 0.5,
-            "plateau_min_delta": 1e-08,
+            "plateau_min_delta": 1e-05,
             "plateau_patience": 5,
             "plateau_cooldown": 3,
             "min_learning_rate": 1e-08
@@ -100,13 +99,13 @@
         },
         "early_stopping": {
             "stop_training_on_plateau": true,
-            "plateau_min_delta": 1e-08,
+            "plateau_min_delta": 1e-06,
             "plateau_patience": 10
         }
     },
     "outputs": {
         "save_outputs": true,
-        "run_name": "pretrained_efficientnetb0.topdown",
+        "run_name": "pretrained.single",
         "run_name_prefix": "",
         "run_name_suffix": null,
         "runs_folder": "models",
@@ -123,7 +122,7 @@
         "tensorboard": {
             "write_logs": false,
             "loss_frequency": "epoch",
-            "architecture_graph": true,
+            "architecture_graph": false,
             "profile_graph": false,
             "visualizations": true
         },

--- a/sleap/training_profiles/pretrained.topdown.json
+++ b/sleap/training_profiles/pretrained.topdown.json
@@ -24,28 +24,26 @@
     "model": {
         "backbone": {
             "leap": null,
-            "unet": {
-                "stem_stride": null,
-                "max_stride": 32,
-                "output_stride": 4,
-                "filters": 32,
-                "filters_rate": 1.5,
-                "middle_block": true,
-                "up_interpolate": true,
-                "stacks": 1
-            },
+            "unet": null,
             "hourglass": null,
             "resnet": null,
-            "pretrained_encoder": null
+            "pretrained_encoder": {
+                "encoder": "efficientnetb0",
+                "pretrained": true,
+                "decoder_filters": 256,
+                "decoder_filters_rate": 1.0,
+                "output_stride": 2
+            }
         },
         "heads": {
-            "single_instance": {
-                "part_names": null,
-                "sigma": 5,
-                "output_stride": 4
-            },
+            "single_instance": null,
             "centroid": null,
-            "centered_instance": null,
+            "centered_instance": {
+                "anchor_part": null,
+                "part_names": null,
+                "sigma": 1.5,
+                "output_stride": 2
+            },
             "multi_instance": null
         }
     },
@@ -81,14 +79,14 @@
         "batches_per_epoch": null,
         "min_batches_per_epoch": 200,
         "val_batches_per_epoch": null,
-        "min_val_batches_per_epoch": 20,
+        "min_val_batches_per_epoch": 10,
         "epochs": 200,
         "optimizer": "adam",
         "initial_learning_rate": 0.0001,
         "learning_rate_schedule": {
             "reduce_on_plateau": true,
             "reduction_factor": 0.5,
-            "plateau_min_delta": 1e-05,
+            "plateau_min_delta": 1e-08,
             "plateau_patience": 5,
             "plateau_cooldown": 3,
             "min_learning_rate": 1e-08
@@ -102,13 +100,13 @@
         },
         "early_stopping": {
             "stop_training_on_plateau": true,
-            "plateau_min_delta": 1e-06,
+            "plateau_min_delta": 1e-08,
             "plateau_patience": 10
         }
     },
     "outputs": {
         "save_outputs": true,
-        "run_name": "baseline_large_rf.single",
+        "run_name": "pretrained.topdown",
         "run_name_prefix": "",
         "run_name_suffix": null,
         "runs_folder": "models",
@@ -125,7 +123,7 @@
         "tensorboard": {
             "write_logs": false,
             "loss_frequency": "epoch",
-            "architecture_graph": false,
+            "architecture_graph": true,
             "profile_graph": false,
             "visualizations": true
         },

--- a/sleap/training_profiles/pretrained.topdown.json
+++ b/sleap/training_profiles/pretrained.topdown.json
@@ -82,7 +82,7 @@
         "min_val_batches_per_epoch": 10,
         "epochs": 200,
         "optimizer": "adam",
-        "initial_learning_rate": 0.0001,
+        "initial_learning_rate": 0.001,
         "learning_rate_schedule": {
             "reduce_on_plateau": true,
             "reduction_factor": 0.5,

--- a/sleap/training_profiles/pretrained_efficientnetb0.topdown.json
+++ b/sleap/training_profiles/pretrained_efficientnetb0.topdown.json
@@ -32,7 +32,7 @@
                 "pretrained": true,
                 "decoder_filters": 256,
                 "decoder_filters_rate": 1.0,
-                "output_stride": 2,
+                "output_stride": 2
             }
         },
         "heads": {

--- a/sleap/training_profiles/pretrained_efficientnetb0.topdown.json
+++ b/sleap/training_profiles/pretrained_efficientnetb0.topdown.json
@@ -1,0 +1,138 @@
+{
+    "data": {
+        "labels": {
+            "training_labels": null,
+            "validation_labels": null,
+            "validation_fraction": 0.1,
+            "test_labels": null,
+            "search_path_hints": [],
+            "skeletons": []
+        },
+        "preprocessing": {
+            "ensure_rgb": false,
+            "ensure_grayscale": false,
+            "imagenet_mode": null,
+            "input_scaling": 1.0,
+            "pad_to_stride": null
+        },
+        "instance_cropping": {
+            "center_on_part": null,
+            "crop_size": null,
+            "crop_size_detection_padding": 16
+        }
+    },
+    "model": {
+        "backbone": {
+            "leap": null,
+            "unet": null,
+            "hourglass": null,
+            "resnet": null,
+            "pretrained_encoder": {
+                "encoder": "efficientnetb0",
+                "pretrained": true,
+                "decoder_filters": 256,
+                "decoder_filters_rate": 1.0,
+                "output_stride": 2,
+            }
+        },
+        "heads": {
+            "single_instance": null,
+            "centroid": null,
+            "centered_instance": {
+                "anchor_part": null,
+                "part_names": null,
+                "sigma": 1.5,
+                "output_stride": 2
+            },
+            "multi_instance": null
+        }
+    },
+    "optimization": {
+        "preload_data": true,
+        "augmentation_config": {
+            "rotate": true,
+            "rotation_min_angle": -180,
+            "rotation_max_angle": 180,
+            "translate": false,
+            "translate_min": -5,
+            "translate_max": 5,
+            "scale": false,
+            "scale_min": 0.9,
+            "scale_max": 1.1,
+            "uniform_noise": false,
+            "uniform_noise_min_val": 0.0,
+            "uniform_noise_max_val": 10.0,
+            "gaussian_noise": false,
+            "gaussian_noise_mean": 5.0,
+            "gaussian_noise_stddev": 1.0,
+            "contrast": false,
+            "contrast_min_gamma": 0.5,
+            "contrast_max_gamma": 2.0,
+            "brightness": false,
+            "brightness_min_val": 0.0,
+            "brightness_max_val": 10.0
+        },
+        "online_shuffling": true,
+        "shuffle_buffer_size": 128,
+        "prefetch": true,
+        "batch_size": 4,
+        "batches_per_epoch": null,
+        "min_batches_per_epoch": 200,
+        "val_batches_per_epoch": null,
+        "min_val_batches_per_epoch": 10,
+        "epochs": 200,
+        "optimizer": "adam",
+        "initial_learning_rate": 0.0001,
+        "learning_rate_schedule": {
+            "reduce_on_plateau": true,
+            "reduction_factor": 0.5,
+            "plateau_min_delta": 1e-08,
+            "plateau_patience": 5,
+            "plateau_cooldown": 3,
+            "min_learning_rate": 1e-08
+        },
+        "hard_keypoint_mining": {
+            "online_mining": false,
+            "hard_to_easy_ratio": 2.0,
+            "min_hard_keypoints": 2,
+            "max_hard_keypoints": null,
+            "loss_scale": 5.0
+        },
+        "early_stopping": {
+            "stop_training_on_plateau": true,
+            "plateau_min_delta": 1e-08,
+            "plateau_patience": 10
+        }
+    },
+    "outputs": {
+        "save_outputs": true,
+        "run_name": "pretrained_efficientnetb0.topdown",
+        "run_name_prefix": "",
+        "run_name_suffix": null,
+        "runs_folder": "models",
+        "tags": [],
+        "save_visualizations": true,
+        "log_to_csv": true,
+        "checkpointing": {
+            "initial_model": false,
+            "best_model": true,
+            "every_epoch": false,
+            "latest_model": false,
+            "final_model": false
+        },
+        "tensorboard": {
+            "write_logs": false,
+            "loss_frequency": "epoch",
+            "architecture_graph": true,
+            "profile_graph": false,
+            "visualizations": true
+        },
+        "zmq": {
+            "subscribe_to_controller": false,
+            "controller_address": "tcp://127.0.0.1:9000",
+            "controller_polling_timeout": 10,
+            "publish_updates": false,
+            "publish_address": "tcp://127.0.0.1:9001"
+        }
+    }
+}

--- a/sleap/training_profiles/pretrained_mobilenetv2.topdown.json
+++ b/sleap/training_profiles/pretrained_mobilenetv2.topdown.json
@@ -32,7 +32,7 @@
                 "pretrained": true,
                 "decoder_filters": 256,
                 "decoder_filters_rate": 1.0,
-                "output_stride": 2,
+                "output_stride": 2
             }
         },
         "heads": {

--- a/sleap/training_profiles/pretrained_mobilenetv2.topdown.json
+++ b/sleap/training_profiles/pretrained_mobilenetv2.topdown.json
@@ -1,0 +1,138 @@
+{
+    "data": {
+        "labels": {
+            "training_labels": null,
+            "validation_labels": null,
+            "validation_fraction": 0.1,
+            "test_labels": null,
+            "search_path_hints": [],
+            "skeletons": []
+        },
+        "preprocessing": {
+            "ensure_rgb": false,
+            "ensure_grayscale": false,
+            "imagenet_mode": null,
+            "input_scaling": 1.0,
+            "pad_to_stride": null
+        },
+        "instance_cropping": {
+            "center_on_part": null,
+            "crop_size": null,
+            "crop_size_detection_padding": 16
+        }
+    },
+    "model": {
+        "backbone": {
+            "leap": null,
+            "unet": null,
+            "hourglass": null,
+            "resnet": null,
+            "pretrained_encoder": {
+                "encoder": "mobilenetv2",
+                "pretrained": true,
+                "decoder_filters": 256,
+                "decoder_filters_rate": 1.0,
+                "output_stride": 2,
+            }
+        },
+        "heads": {
+            "single_instance": null,
+            "centroid": null,
+            "centered_instance": {
+                "anchor_part": null,
+                "part_names": null,
+                "sigma": 1.5,
+                "output_stride": 2
+            },
+            "multi_instance": null
+        }
+    },
+    "optimization": {
+        "preload_data": true,
+        "augmentation_config": {
+            "rotate": true,
+            "rotation_min_angle": -180,
+            "rotation_max_angle": 180,
+            "translate": false,
+            "translate_min": -5,
+            "translate_max": 5,
+            "scale": false,
+            "scale_min": 0.9,
+            "scale_max": 1.1,
+            "uniform_noise": false,
+            "uniform_noise_min_val": 0.0,
+            "uniform_noise_max_val": 10.0,
+            "gaussian_noise": false,
+            "gaussian_noise_mean": 5.0,
+            "gaussian_noise_stddev": 1.0,
+            "contrast": false,
+            "contrast_min_gamma": 0.5,
+            "contrast_max_gamma": 2.0,
+            "brightness": false,
+            "brightness_min_val": 0.0,
+            "brightness_max_val": 10.0
+        },
+        "online_shuffling": true,
+        "shuffle_buffer_size": 128,
+        "prefetch": true,
+        "batch_size": 4,
+        "batches_per_epoch": null,
+        "min_batches_per_epoch": 200,
+        "val_batches_per_epoch": null,
+        "min_val_batches_per_epoch": 10,
+        "epochs": 200,
+        "optimizer": "adam",
+        "initial_learning_rate": 0.0001,
+        "learning_rate_schedule": {
+            "reduce_on_plateau": true,
+            "reduction_factor": 0.5,
+            "plateau_min_delta": 1e-08,
+            "plateau_patience": 5,
+            "plateau_cooldown": 3,
+            "min_learning_rate": 1e-08
+        },
+        "hard_keypoint_mining": {
+            "online_mining": false,
+            "hard_to_easy_ratio": 2.0,
+            "min_hard_keypoints": 2,
+            "max_hard_keypoints": null,
+            "loss_scale": 5.0
+        },
+        "early_stopping": {
+            "stop_training_on_plateau": true,
+            "plateau_min_delta": 1e-08,
+            "plateau_patience": 10
+        }
+    },
+    "outputs": {
+        "save_outputs": true,
+        "run_name": "pretrained_mobilenetv2.topdown",
+        "run_name_prefix": "",
+        "run_name_suffix": null,
+        "runs_folder": "models",
+        "tags": [],
+        "save_visualizations": true,
+        "log_to_csv": true,
+        "checkpointing": {
+            "initial_model": false,
+            "best_model": true,
+            "every_epoch": false,
+            "latest_model": false,
+            "final_model": false
+        },
+        "tensorboard": {
+            "write_logs": false,
+            "loss_frequency": "epoch",
+            "architecture_graph": true,
+            "profile_graph": false,
+            "visualizations": true
+        },
+        "zmq": {
+            "subscribe_to_controller": false,
+            "controller_address": "tcp://127.0.0.1:9000",
+            "controller_polling_timeout": 10,
+            "publish_updates": false,
+            "publish_address": "tcp://127.0.0.1:9001"
+        }
+    }
+}

--- a/tests/gui/test_inference_gui.py
+++ b/tests/gui/test_inference_gui.py
@@ -11,7 +11,9 @@ def test_config_list_load():
         "centroid"
     )
 
-    assert 2 == len(configs)
+    assert len(configs) > 0
+    for cfg in configs:
+        assert cfg.config.model.heads.which_oneof_attrib_name() == "centroid"
 
 
 def test_config_list_order():

--- a/tests/nn/architectures/test_pretrained_encoders.py
+++ b/tests/nn/architectures/test_pretrained_encoders.py
@@ -3,7 +3,7 @@ import tensorflow as tf
 from sleap.nn.system import use_cpu_only; use_cpu_only()  # hide GPUs for test
 
 from sleap.nn.architectures import UnetPretrainedEncoder
-from sleap.nn.config import UnetPretrainedEncoderConfig
+from sleap.nn.config import PretrainedEncoderConfig
 
 
 def test_unet_pretrained_backbone():
@@ -27,7 +27,7 @@ def test_unet_pretrained_backbone():
 
 def test_unet_pretrained_backbone_from_config():
     backbone = UnetPretrainedEncoder.from_config(
-        UnetPretrainedEncoderConfig(
+        PretrainedEncoderConfig(
             encoder="resnet18",
             pretrained=False,
             decoder_filters=256,

--- a/tests/nn/architectures/test_pretrained_encoders.py
+++ b/tests/nn/architectures/test_pretrained_encoders.py
@@ -1,0 +1,42 @@
+import numpy as np
+import tensorflow as tf
+from sleap.nn.system import use_cpu_only; use_cpu_only()  # hide GPUs for test
+
+from sleap.nn.architectures import UnetPretrainedEncoder
+from sleap.nn.config import UnetPretrainedEncoderConfig
+
+
+def test_unet_pretrained_backbone():
+    backbone = UnetPretrainedEncoder(
+        encoder="mobilenetv2",
+        decoder_filters=(32, 32, 32, 32),
+        pretrained=True,
+    )
+    assert backbone.pretrained
+    assert backbone.down_blocks == 5
+    assert backbone.up_blocks == 4
+    assert backbone.maximum_stride == 32
+    assert backbone.output_stride == 2
+
+    x_in = tf.keras.layers.Input([256, 256, 1])
+    x, intermediate_feats = backbone.make_backbone(x_in)
+
+    assert tuple(x.shape) == (None, 128, 128, 32)
+    assert len(intermediate_feats) == 4
+
+
+def test_unet_pretrained_backbone_from_config():
+    backbone = UnetPretrainedEncoder.from_config(
+        UnetPretrainedEncoderConfig(
+            encoder="resnet18",
+            pretrained=False,
+            decoder_filters=256,
+            decoder_filters_rate=0.5,
+            output_stride=1,
+        )
+    )
+
+    assert backbone.decoder_filters == (256, 128, 64, 32, 16)
+    assert not backbone.pretrained
+    assert backbone.encoder == "resnet18"
+    assert backbone.output_stride == 1

--- a/tests/nn/architectures/test_pretrained_encoders.py
+++ b/tests/nn/architectures/test_pretrained_encoders.py
@@ -8,7 +8,8 @@ from sleap.nn.config import PretrainedEncoderConfig
 
 
 @pytest.mark.parametrize("pretrained", [False, True])
-def test_unet_pretrained_backbone(pretrained):
+@pytest.mark.parametrize("input_channels", [1, 3])
+def test_unet_pretrained_backbone(pretrained, input_channels):
     backbone = UnetPretrainedEncoder(
         encoder="resnet18",
         decoder_filters=(64, 32, 16, 8),
@@ -20,7 +21,7 @@ def test_unet_pretrained_backbone(pretrained):
     assert backbone.maximum_stride == 32
     assert backbone.output_stride == 2
 
-    x_in = tf.keras.layers.Input([256, 256, 1])
+    x_in = tf.keras.layers.Input([256, 256, input_channels])
     x, intermediate_feats = backbone.make_backbone(x_in)
 
     assert tuple(x.shape) == (None, 128, 128, 8)
@@ -31,7 +32,7 @@ def test_unet_pretrained_backbone(pretrained):
     assert tuple(intermediate_feats[3].tensor.shape) == (None, 128, 128, 8)
 
     model = tf.keras.Model(x_in, x)
-    preds = model.predict(np.zeros([1, 256, 256, 1], dtype="float32"))
+    preds = model.predict(np.zeros([1, 256, 256, input_channels], dtype="float32"))
     assert preds.shape == (1, 128, 128, 8)
 
 

--- a/tests/nn/architectures/test_pretrained_encoders.py
+++ b/tests/nn/architectures/test_pretrained_encoders.py
@@ -1,18 +1,20 @@
 import numpy as np
 import tensorflow as tf
+import pytest
 from sleap.nn.system import use_cpu_only; use_cpu_only()  # hide GPUs for test
 
 from sleap.nn.architectures import UnetPretrainedEncoder
 from sleap.nn.config import PretrainedEncoderConfig
 
 
-def test_unet_pretrained_backbone():
+@pytest.mark.parametrize("pretrained", [False, True])
+def test_unet_pretrained_backbone(pretrained):
     backbone = UnetPretrainedEncoder(
-        encoder="mobilenetv2",
-        decoder_filters=(32, 32, 32, 32),
-        pretrained=True,
+        encoder="resnet18",
+        decoder_filters=(64, 32, 16, 8),
+        pretrained=pretrained,
     )
-    assert backbone.pretrained
+    assert backbone.pretrained == pretrained
     assert backbone.down_blocks == 5
     assert backbone.up_blocks == 4
     assert backbone.maximum_stride == 32
@@ -21,8 +23,16 @@ def test_unet_pretrained_backbone():
     x_in = tf.keras.layers.Input([256, 256, 1])
     x, intermediate_feats = backbone.make_backbone(x_in)
 
-    assert tuple(x.shape) == (None, 128, 128, 32)
+    assert tuple(x.shape) == (None, 128, 128, 8)
     assert len(intermediate_feats) == 4
+    assert tuple(intermediate_feats[0].tensor.shape) == (None, 16, 16, 64)
+    assert tuple(intermediate_feats[1].tensor.shape) == (None, 32, 32, 32)
+    assert tuple(intermediate_feats[2].tensor.shape) == (None, 64, 64, 16)
+    assert tuple(intermediate_feats[3].tensor.shape) == (None, 128, 128, 8)
+
+    model = tf.keras.Model(x_in, x)
+    preds = model.predict(np.zeros([1, 256, 256, 1], dtype="float32"))
+    assert preds.shape == (1, 128, 128, 8)
 
 
 def test_unet_pretrained_backbone_from_config():


### PR DESCRIPTION
This PR adds a new architecture to create SLEAP models based on the awesome [`segmentation_models`](https://github.com/qubvel/segmentation_models) package.

This includes 32(!) optionally pretrained models to use as an encoder in UNet-style encoder-decoder models. This is similar to how we implemented pretrained ResNet previously (`sleap.nn.architectures.resnet`), but also includes skip connections from each block in the encoder branch! What it does not do is afford the ability to convert striding into dilations to retain feature map resolution (though this is ameliorated somewhat by the skip connections).

This adds the `sleap.nn.architectures.pretrained_encoders` module and the associated configuration, tests and model instantiation.

This should finally close #191!