### PR TITLE
Add a couple of top level aliases from nn.system module

### DIFF
--- a/sleap/__init__.py
+++ b/sleap/__init__.py
@@ -13,5 +13,6 @@ import sleap.nn
 from sleap.nn.data import pipelines
 from sleap.nn import inference
 from sleap.nn.inference import load_model
-
+from sleap.nn.system import use_cpu_only, disable_preallocation
+from sleap.nn.system import summary as system_summary
 from sleap.version import __version__


### PR DESCRIPTION
Convenience APIs:

- `sleap.use_cpu_only()`: hide GPUs from TensorFlow
- `sleap.disable_preallocation()`: prevent TensorFlow from allocating entire GPU memory (crashes on some *nix systems)
- `sleap.system_summary()`: prints info on the GPUs available, if any