### PR TITLE
Miscellaneous QOL

### DIFF
--- a/.conda/bld.bat
+++ b/.conda/bld.bat
@@ -38,6 +38,7 @@ pip install jsmin
 pip install seaborn
 pip install pykalman==0.9.5
 pip install segmentation-models==1.0.1
+pip install rich==9.10.0
 
 rem # Use and update environment.yml call to install pip dependencies. This is slick.
 rem # While environment.yml contains the non pip dependencies, the only thing left

--- a/.conda/build.sh
+++ b/.conda/build.sh
@@ -36,6 +36,7 @@ pip install jsmin
 pip install seaborn
 pip install pykalman==0.9.5
 pip install segmentation-models==1.0.1
+pip install rich==9.10.0
 
 pip install setuptools-scm
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,15 +89,13 @@ pygments_style = None
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = "alabaster"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-html_theme_options = {
-    'font_size': '15px'
-}
+html_theme_options = {"font_size": "15px"}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ jsmin
 seaborn
 pykalman==0.9.5
 segmentation-models==1.0.1
+rich==9.10.0

--- a/setup.py
+++ b/setup.py
@@ -32,10 +32,10 @@ setup(
     setup_requires=["setuptools_scm"],
     install_requires=get_requirements(),
     extras_require={"dev": get_requirements("dev"),},
-    description="SLEAP (Social LEAP Estimates Animal Pose) is a deep learning framework for estimating animal pose.",
+    description="SLEAP (Social LEAP Estimates Animal Poses) is a deep learning framework for animal pose tracking.",
     long_description=long_description,
     long_description_content_type="text/x-rst",
-    author="Talmo Pereira, David Turner, Nat Tabris",
+    author="Talmo Pereira, Arie Matsliah, David Turner, Nat Tabris",
     author_email="talmo@princeton.edu",
     project_urls={
         "Documentation": "https://sleap.ai/#sleap",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open(path.join(here, "README.rst"), encoding="utf-8") as f:
 # Get the sleap version
 with open(path.join(here, "sleap/version.py")) as f:
     version_file = f.read()
-    sleap_version = re.search("__version__ = \"([0-9\\.a]+)\"", version_file).group(1)
+    sleap_version = re.search('__version__ = "([0-9\\.a]+)"', version_file).group(1)
 
 
 def get_requirements(require_name=None):
@@ -31,7 +31,9 @@ setup(
     version=sleap_version,
     setup_requires=["setuptools_scm"],
     install_requires=get_requirements(),
-    extras_require={"dev": get_requirements("dev"),},
+    extras_require={
+        "dev": get_requirements("dev"),
+    },
     description="SLEAP (Social LEAP Estimates Animal Poses) is a deep learning framework for animal pose tracking.",
     long_description=long_description,
     long_description_content_type="text/x-rst",

--- a/sleap/config/shortcuts.yaml
+++ b/sleap/config/shortcuts.yaml
@@ -1,7 +1,7 @@
 add instance: Ctrl+I
 add videos: Ctrl+A
 clear selection: Esc
-close: QKeySequence.Close
+close: Ctrl+Q
 color predicted: 
 delete area: Ctrl+K
 delete clip:
@@ -11,19 +11,19 @@ export clip:
 fit: Ctrl+=
 goto frame: Ctrl+J
 goto marked: Ctrl+Shift+M
-goto next suggestion: QKeySequence.FindNext
+goto next suggestion: Space
 goto next track spawn: Ctrl+E
-goto next user: Ctrl+>
-goto next labeled: Ctrl+.
-goto prev suggestion: QKeySequence.FindPrevious
-goto prev labeled: 
+goto next user: Ctrl+U
+goto next labeled: Alt+Right
+goto prev suggestion: Shift+Space
+goto prev labeled: Alt+Left
 learning: Ctrl+L
 mark frame: Ctrl+M
 new: Ctrl+N
 next video: QKeySequence.Forward
 open: Ctrl+O
 prev video: QKeySequence.Back
-save as: QKeySequence.SaveAs
+save as: Ctrl+Shift+S
 save: Ctrl+S
 select next: '`'
 select to frame: Ctrl+Shift+J
@@ -33,7 +33,7 @@ show trails:
 transpose: Ctrl+T
 frame next: Right
 frame prev: Left
-frame next medium step: Down
-frame prev medium step: Up
-frame next large step: Space
-frame prev large step: /
+frame next medium step: Ctrl+Right
+frame prev medium step: Ctrl+Left
+frame next large step: Ctrl+Alt+Right
+frame prev large step: Ctrl+Alt+Left

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -663,6 +663,7 @@ class MainWindow(QMainWindow):
 
         predictionMenu.addSeparator()
 
+
         add_menu_item(
             predictionMenu,
             "show metrics",
@@ -678,10 +679,21 @@ class MainWindow(QMainWindow):
         )
 
         predictionMenu.addSeparator()
+
+        training_package_menu = predictionMenu.addMenu("Export Training Package...")
         add_menu_item(
-            predictionMenu,
+            training_package_menu,
+            "export user labels package",
+            "Labeled frames",
+            self.commands.exportUserLabelsPackage,
+        ).setToolTip(
+            "Export user-labeled frames with image data into a single SLP file.\n\n"
+            "Use this for archiving a dataset with labeled frames only."
+        )
+        add_menu_item(
+            training_package_menu,
             "export training package",
-            "Export Training Package...",
+            "Labeled + suggested frames (recommended)",
             self.commands.exportTrainingPackage,
         ).setToolTip(
             "Export user-labeled frames and suggested frames with image data into a "
@@ -690,18 +702,9 @@ class MainWindow(QMainWindow):
             "unlabeled frames."
         )
         add_menu_item(
-            predictionMenu,
-            "export user labels package",
-            "Export Package with User Labels Only...",
-            self.commands.exportUserLabelsPackage,
-        ).setToolTip(
-            "Export user-labeled frames with image data into a single SLP file.\n\n"
-            "Use this for archiving a dataset with labeled frames only."
-        )
-        add_menu_item(
-            predictionMenu,
+            training_package_menu,
             "export full package",
-            "Export Package with All Labels...",
+            "Labeled + predicted + suggested frames",
             self.commands.exportFullPackage,
         ).setToolTip(
             "Export all frames (including predictions) and suggested frames with image "

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -359,13 +359,16 @@ class MainWindow(QMainWindow):
         fileMenu.addSeparator()
         add_menu_item(fileMenu, "save", "Save", self.commands.saveProject)
         add_menu_item(fileMenu, "save as", "Save As...", self.commands.saveProjectAs)
-
-        fileMenu.addSeparator()
         add_menu_item(
             fileMenu,
             "export analysis",
             "Export Analysis HDF5...",
             self.commands.exportAnalysisFile,
+        )
+
+        fileMenu.addSeparator()
+        add_menu_item(
+            fileMenu, "reset prefs", "Reset preferences to defaults...", self.resetPrefs
         )
 
         fileMenu.addSeparator()
@@ -662,7 +665,6 @@ class MainWindow(QMainWindow):
         )
 
         predictionMenu.addSeparator()
-
 
         add_menu_item(
             predictionMenu,
@@ -1219,6 +1221,15 @@ class MainWindow(QMainWindow):
                     message += " in video"
 
         self.statusBar().showMessage(message)
+
+    def resetPrefs(self):
+        """Reset preferences to defaults."""
+        prefs.reset_to_default()
+        msg = QMessageBox()
+        msg.setText(
+            "Note: Some preferences may not take effect until application is restarted."
+        )
+        msg.exec_()
 
     def loadProjectFile(self, filename: Optional[str] = None):
         """

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1012,7 +1012,8 @@ class MainWindow(QMainWindow):
         suggestions_layout.addWidget(hbw)
 
         self.suggestions_form_widget = YamlFormWidget.from_name(
-            "suggestions", title="Generate Suggestions",
+            "suggestions",
+            title="Generate Suggestions",
         )
         self.suggestions_form_widget.mainAction.connect(
             self.process_events_then(self.commands.generateSuggestions)
@@ -1513,7 +1514,9 @@ class MainWindow(QMainWindow):
 
         if self._child_windows.get(mode, None) is None:
             self._child_windows[mode] = LearningDialog(
-                mode, self.state["filename"], self.labels,
+                mode,
+                self.state["filename"],
+                self.labels,
             )
             self._child_windows[mode]._handle_learning_finished.connect(
                 self._handle_learning_finished

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -140,6 +140,8 @@ class MainWindow(QMainWindow):
         self.state["edge style"] = "Line"
         self.state["fit"] = False
         self.state["color predicted"] = prefs["color predicted"]
+        self.state["marker size"] = prefs["marker size"]
+        self.state.connect("marker size", self.plotFrame)
 
         self.release_checker = ReleaseChecker()
 
@@ -184,6 +186,7 @@ class MainWindow(QMainWindow):
         """Closes application window, prompting for saving as needed."""
         # Save window state.
         prefs["window state"] = self.saveState()
+        prefs["marker size"] = self.state["marker size"]
 
         # Save preferences.
         prefs.save()
@@ -507,8 +510,15 @@ class MainWindow(QMainWindow):
 
         add_submenu_choices(
             menu=viewMenu,
+            title="Node Marker Size",
+            options=(1, 4, 6, 8, 12),
+            key="marker size",
+        )
+
+        add_submenu_choices(
+            menu=viewMenu,
             title="Trail Length",
-            options=(0, 10, 20, 50, 100, 200, 500),
+            options=(0, 10, 50, 100, 250),
             key="trail_length",
         )
 
@@ -935,7 +945,6 @@ class MainWindow(QMainWindow):
 
         suggestions_layout.addWidget(self.suggestionsTable)
 
-        
         hb = QHBoxLayout()
 
         _add_button(
@@ -1625,7 +1634,7 @@ def main():
         help=(
             "Reset GUI state and preferences. Use this flag if the GUI appears "
             "incorrectly or fails to open."
-            ),
+        ),
         action="store_const",
         const=True,
         default=False,

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1588,8 +1588,15 @@ def main():
     window = MainWindow(labels_path=args.labels_path)
     window.showMaximized()
 
-    # Disable GPU in GUI process.
+    # Disable GPU in GUI process. This does not affect subprocesses.
     sleap.use_cpu_only()
+
+    # Print versions.
+    print()
+    print("Software versions:")
+    sleap.versions()
+    print()
+    print("Happy SLEAPing! :)")
 
     if args.profiling:
         import cProfile

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -733,7 +733,7 @@ class MainWindow(QMainWindow):
 
         helpMenu.addSeparator()
 
-        helpMenu.addAction("Check for updates...", self.commands.checkForUpdates)
+        helpMenu.addAction("Latest versions:", self.commands.checkForUpdates)
         self.state["stable_version_menu"] = helpMenu.addAction(
             "  Stable: N/A", self.commands.openStableVersion
         )

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -790,11 +790,6 @@ class MainWindow(QMainWindow):
             dock_widget.setLayout(layout)
             dock.setWidget(dock_widget)
 
-            # key = f"hide {name.lower()} dock"
-            # print(f"prefs[{key}] = {prefs[key]}")
-            # if key in prefs and prefs[key]:
-            # dock.hide()
-
             self.addDockWidget(Qt.RightDockWidgetArea, dock)
             self.viewMenu.addAction(dock.toggleViewAction())
 
@@ -939,6 +934,34 @@ class MainWindow(QMainWindow):
         )
 
         suggestions_layout.addWidget(self.suggestionsTable)
+
+        
+        hb = QHBoxLayout()
+
+        _add_button(
+            hb,
+            "Add current frame",
+            self.process_events_then(self.commands.addCurrentFrameAsSuggestion),
+            "add current frame as suggestion",
+        )
+
+        _add_button(
+            hb,
+            "Remove",
+            self.process_events_then(self.commands.removeSuggestion),
+            "remove suggestion",
+        )
+
+        _add_button(
+            hb,
+            "Clear all",
+            self.process_events_then(self.commands.clearSuggestions),
+            "clear suggestions",
+        )
+
+        hbw = QWidget()
+        hbw.setLayout(hb)
+        suggestions_layout.addWidget(hbw)
 
         hb = QHBoxLayout()
 

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -664,6 +664,8 @@ class MainWindow(QMainWindow):
 
         tracksMenu = self.menuBar().addMenu("Tracks")
         self.track_menu = tracksMenu.addMenu("Set Instance Track")
+        self.delete_tracks_menu = tracksMenu.addMenu("Delete Track")
+        self.delete_tracks_menu.setEnabled(False)
         add_menu_check_item(
             tracksMenu, "propagate track labels", "Propagate Track Labels"
         ).setToolTip(
@@ -1098,6 +1100,7 @@ class MainWindow(QMainWindow):
         # Update menus
 
         self.track_menu.setEnabled(has_selected_instance)
+        self.delete_tracks_menu.setEnabled(has_tracks)
         self._menu_actions["clear selection"].setEnabled(has_selected_instance)
         self._menu_actions["delete instance"].setEnabled(has_selected_instance)
 
@@ -1361,14 +1364,18 @@ class MainWindow(QMainWindow):
     def _update_track_menu(self):
         """Updates track menu options."""
         self.track_menu.clear()
-        for track in self.labels.tracks:
+        self.delete_tracks_menu.clear()
+        for track_ind, track in enumerate(self.labels.tracks):
             key_command = ""
-            if self.labels.tracks.index(track) < 9:
+            if track_ind < 9:
                 key_command = Qt.CTRL + Qt.Key_0 + self.labels.tracks.index(track) + 1
             self.track_menu.addAction(
                 f"{track.name}",
                 lambda x=track: self.commands.setInstanceTrack(x),
                 key_command,
+            )
+            self.delete_tracks_menu.addAction(
+                f"{track.name}", lambda x=track: self.commands.deleteTrack(x)
             )
         self.track_menu.addAction(
             "New Track", self.commands.addTrack, Qt.CTRL + Qt.Key_0

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1963,7 +1963,7 @@ class ClearSuggestions(EditCommand):
 
     @classmethod
     def do_action(cls, context: CommandContext, params: dict):
-        context.labels.suggestions = []
+        context.labels.clear_suggestions()
 
 
 class MergeProject(EditCommand):

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -2052,7 +2052,8 @@ class AddInstance(EditCommand):
         if context.state["labeled_frame"] is None:
             return
 
-        # FIXME: filter by skeleton type
+        if len(context.state["skeleton"]) == 0:
+            return
 
         from_predicted = copy_instance
         from_prev_frame = False

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1885,7 +1885,11 @@ class GenerateSuggestions(EditCommand):
     def do_action(cls, context: CommandContext, params: dict):
 
         # TODO: Progress bar
-        win = MessageDialog("Generating list of suggested frames...", context.app)
+        win = MessageDialog(
+            "Generating list of suggested frames... "
+            "This may take a few minutes.",
+            context.app
+        )
 
         new_suggestions = VideoFrameSuggestions.suggest(
             labels=context.labels, params=params
@@ -1929,7 +1933,7 @@ class ClearSuggestions(EditCommand):
 
         # Warn that suggestions will be cleared
         
-        response = QMessageBox.critical(
+        response = QMessageBox.warning(
             context.app,
             "Clearing all suggestions",
             "Are you sure you want to remove all suggestions from the project?",

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -647,7 +647,9 @@ class ImportLEAP(AppCommand):
     @staticmethod
     def do_action(context: "CommandContext", params: dict):
 
-        labels = Labels.load_leap_matlab(filename=params["filename"],)
+        labels = Labels.load_leap_matlab(
+            filename=params["filename"],
+        )
 
         new_window = context.app.__class__()
         new_window.showMaximized()

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -501,6 +501,10 @@ class CommandContext:
         """Sets track for selected instance."""
         self.execute(SetSelectedInstanceTrack, new_track=new_track)
 
+    def deleteTrack(self, track: "Track"):
+        """Delete a track and remove from all instances."""
+        self.execute(DeleteTrack, track=track)
+
     def setTrackName(self, track: "Track", name: str):
         """Sets name for track."""
         self.execute(SetTrackName, track=track, name=name)
@@ -643,9 +647,7 @@ class ImportLEAP(AppCommand):
     @staticmethod
     def do_action(context: "CommandContext", params: dict):
 
-        labels = Labels.load_leap_matlab(
-            filename=params["filename"],
-        )
+        labels = Labels.load_leap_matlab(filename=params["filename"],)
 
         new_window = context.app.__class__()
         new_window.showMaximized()
@@ -1867,7 +1869,10 @@ class SetSelectedInstanceTrack(EditCommand):
 
         # When setting track for an instance that doesn't already have a track set,
         # just set for selected instance.
-        if selected_instance.track is None or not context.state["propagate track labels"]:
+        if (
+            selected_instance.track is None
+            or not context.state["propagate track labels"]
+        ):
             # Move anything already in the new track out of it
             new_track_instances = context.labels.find_track_occupancy(
                 video=context.state["video"],
@@ -1907,6 +1912,15 @@ class SetSelectedInstanceTrack(EditCommand):
 
         # Make sure the originally selected instance is still selected
         context.state["instance"] = selected_instance
+
+
+class DeleteTrack(EditCommand):
+    topics = [UpdateTopic.tracks]
+
+    @staticmethod
+    def do_action(context: CommandContext, params: dict):
+        track = params["track"]
+        context.labels.remove_track(track)
 
 
 class SetTrackName(EditCommand):

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -2204,6 +2204,7 @@ class AddMissingInstanceNodes(EditCommand):
 
     @classmethod
     def add_random_nodes(cls, context, instance, visible):
+        # TODO: Move this to Instance so we can do this on-demand
         # the rect that's currently visible in the window view
         in_view_rect = context.app.player.getVisibleRect()
 

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1865,11 +1865,9 @@ class SetSelectedInstanceTrack(EditCommand):
         if selected_instance is None:
             return
 
-        old_track = selected_instance.track
-
         # When setting track for an instance that doesn't already have a track set,
         # just set for selected instance.
-        if old_track is None:
+        if selected_instance.track is None or not context.state["propagate track labels"]:
             # Move anything already in the new track out of it
             new_track_instances = context.labels.find_track_occupancy(
                 video=context.state["video"],
@@ -1889,6 +1887,7 @@ class SetSelectedInstanceTrack(EditCommand):
         # When the instance does already have a track, then we want to update
         # the track for a range of frames.
         else:
+            old_track = selected_instance.track
 
             # Determine range that should be affected
             if context.state["has_frame_range"]:

--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -303,8 +303,7 @@ class GenericTableView(QtWidgets.QTableView):
             self.state[self.name_prefix + self.row_name] = item
 
     def activateSelected(self, *args):
-        """
-        Activates item currently selected in table.
+        """Activate item currently selected in table.
 
         "Activate" means that the relevant :py:class:`GuiState` state variable
         is set to the currently selected item.
@@ -313,8 +312,7 @@ class GenericTableView(QtWidgets.QTableView):
             self.state[self.row_name] = self.getSelectedRowItem()
 
     def selectRowItem(self, item: Any):
-        """
-        Selects row corresponding to item.
+        """Select row corresponding to item.
 
         If the table model converts items to dictionaries (using `item_to_data`
         method), then `item` argument should be the original item, not the
@@ -330,9 +328,12 @@ class GenericTableView(QtWidgets.QTableView):
         if self.row_name:
             self.state[self.name_prefix + self.row_name] = item
 
+    def selectRow(self, idx: int):
+        """Select row corresponding to index."""
+        self.selectRowItem(self.model().original_items[idx])
+
     def getSelectedRowItem(self) -> Any:
-        """
-        Returns item corresponding to currently selected row.
+        """Return item corresponding to currently selected row.
 
         Note that if the table model converts items to dictionaries (using
         `item_to_data` method), then returned item will be the original item,

--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -462,7 +462,10 @@ class SuggestionsTableModel(GenericTableModel):
 
         item_dict["SuggestionFrame"] = item
 
-        video_string = f"{labels.videos.index(item.video)+1}: {os.path.basename(item.video.filename)}"
+        video_string = (
+            f"{labels.videos.index(item.video)+1}: "
+            f"{os.path.basename(item.video.filename)}"
+        )
 
         item_dict["group"] = str(item.group + 1) if item.group is not None else ""
         item_dict["group_int"] = item.group if item.group is not None else -1

--- a/sleap/gui/dialogs/shortcuts.py
+++ b/sleap/gui/dialogs/shortcuts.py
@@ -28,11 +28,26 @@ class ShortcutDialog(QtWidgets.QDialog):
         for action, widget in self.key_widgets.items():
             self.shortcuts[action] = widget.keySequence().toString()
         self.shortcuts.save()
+        self.info_msg()
+        super(ShortcutDialog, self).accept()
 
+    def info_msg(self):
+        """Display information about changes."""
+        msg = QtWidgets.QMessageBox()
+        msg.setText(
+            "Application must be restarted before changes to keyboard shortcuts take "
+            "effect."
+        )
+        msg.exec_()
+
+    def reset(self):
+        """Reset to defaults."""
+        self.shortcuts.reset_to_default()
+        self.info_msg()
         super(ShortcutDialog, self).accept()
 
     def load_shortcuts(self):
-        """Loads shortcuts object."""
+        """Load shortcuts object."""
         self.shortcuts = Shortcuts()
 
     def make_form(self):
@@ -41,26 +56,28 @@ class ShortcutDialog(QtWidgets.QDialog):
 
         layout = QtWidgets.QVBoxLayout()
         layout.addWidget(self.make_shortcuts_widget())
-        layout.addWidget(
-            QtWidgets.QLabel(
-                "Any changes to keyboard shortcuts will not take effect "
-                "until you quit and re-open the application."
-            )
-        )
         layout.addWidget(self.make_buttons_widget())
         self.setLayout(layout)
 
     def make_buttons_widget(self) -> QtWidgets.QDialogButtonBox:
-        """Makes the form buttons."""
-        buttons = QtWidgets.QDialogButtonBox(
-            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel
-        )
-        buttons.accepted.connect(self.accept)
-        buttons.rejected.connect(self.reject)
+        """Make the form buttons."""
+        buttons = QtWidgets.QDialogButtonBox()
+        save = QtWidgets.QPushButton("Save")
+        save.clicked.connect(self.accept)
+        buttons.addButton(save, QtWidgets.QDialogButtonBox.AcceptRole)
+
+        cancel = QtWidgets.QPushButton("Cancel")
+        cancel.clicked.connect(self.reject)
+        buttons.addButton(cancel, QtWidgets.QDialogButtonBox.RejectRole)
+
+        reset = QtWidgets.QPushButton("Reset to defaults")
+        reset.clicked.connect(self.reset)
+        buttons.addButton(reset, QtWidgets.QDialogButtonBox.ActionRole)
+
         return buttons
 
     def make_shortcuts_widget(self) -> QtWidgets.QWidget:
-        """Makes the widget will fields for all shortcuts."""
+        """Make the widget will fields for all shortcuts."""
         shortcuts = self.shortcuts
 
         widget = QtWidgets.QWidget()
@@ -75,7 +92,7 @@ class ShortcutDialog(QtWidgets.QDialog):
         return widget
 
     def make_column_widget(self, shortcuts: List) -> QtWidgets.QWidget:
-        """Makes a single column of shortcut fields.
+        """Make a single column of shortcut fields.
 
         Args:
             shortcuts: The list of shortcuts to include in this column.

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -91,9 +91,7 @@ class LearningDialog(QtWidgets.QDialog):
             "Export training job package...", QtWidgets.QDialogButtonBox.ActionRole
         )
         self.cancel_button = buttons.addButton(QtWidgets.QDialogButtonBox.Cancel)
-        self.run_button = buttons.addButton(
-            "Run", QtWidgets.QDialogButtonBox.ApplyRole
-        )
+        self.run_button = buttons.addButton("Run", QtWidgets.QDialogButtonBox.ApplyRole)
 
         self.save_button.setToolTip("Save scripts and configuration to run pipeline.")
         self.export_button.setToolTip(

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -16,9 +16,6 @@ from typing import Dict, List, Optional, Text
 from PySide2 import QtWidgets, QtCore
 
 
-# Debug option to skip the training run
-SKIP_TRAINING = False
-
 # List of fields which should show list of skeleton nodes
 NODE_LIST_FIELDS = [
     "data.instance_cropping.center_on_part",

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -3,15 +3,18 @@ Dialogs for running training and/or inference in GUI.
 """
 import cattr
 import os
+import shutil
+import atexit
+import tempfile
+from pathlib import Path
 
-import networkx as nx
-
+import sleap
 from sleap import Labels, Video
 from sleap.gui.dialogs.filedialog import FileDialog
 from sleap.gui.dialogs.formbuilder import YamlFormWidget
 from sleap.gui.learning import runners, scopedkeydict, configs, datagen, receptivefield
 
-from typing import Dict, List, Optional, Text
+from typing import Dict, List, Optional, Text, Optional
 
 from PySide2 import QtWidgets, QtCore
 
@@ -81,13 +84,22 @@ class LearningDialog(QtWidgets.QDialog):
 
         # Layout for buttons
         buttons = QtWidgets.QDialogButtonBox()
-        self.cancel_button = buttons.addButton(QtWidgets.QDialogButtonBox.Cancel)
         self.save_button = buttons.addButton(
-            "Save configuration files...", QtWidgets.QDialogButtonBox.ApplyRole
+            "Save configuration files...", QtWidgets.QDialogButtonBox.ActionRole
         )
+        self.export_button = buttons.addButton(
+            "Export training job package...", QtWidgets.QDialogButtonBox.ActionRole
+        )
+        self.cancel_button = buttons.addButton(QtWidgets.QDialogButtonBox.Cancel)
         self.run_button = buttons.addButton(
-            "Run", QtWidgets.QDialogButtonBox.AcceptRole
+            "Run", QtWidgets.QDialogButtonBox.ApplyRole
         )
+
+        self.save_button.setToolTip("Save scripts and configuration to run pipeline.")
+        self.export_button.setToolTip(
+            "Export data, configuration, and scripts for remote training and inference."
+        )
+        self.run_button.setToolTip("Run pipeline locally (GPU recommended).")
 
         buttons_layout = QtWidgets.QHBoxLayout()
         buttons_layout.addWidget(buttons, alignment=QtCore.Qt.AlignTop)
@@ -129,9 +141,10 @@ class LearningDialog(QtWidgets.QDialog):
         self.connect_signals()
 
         # Connect actions for buttons
-        buttons.accepted.connect(self.run)
-        buttons.rejected.connect(self.reject)
-        buttons.clicked.connect(self.on_button_click)
+        self.save_button.clicked.connect(self.save)
+        self.export_button.clicked.connect(self.export_package)
+        self.cancel_button.clicked.connect(self.reject)
+        self.run_button.clicked.connect(self.run)
 
         # Connect button for previewing the training data
         if "_view_datagen" in self.pipeline_form_widget.buttons:
@@ -447,8 +460,6 @@ class LearningDialog(QtWidgets.QDialog):
         frame_count = self.count_total_frames_for_selection_option(frame_selection)
 
         if predict_frames_choice.startswith("user"):
-            # For inference on user labeled frames, we'll have a single
-            # inference item.
             items_for_inference = runners.ItemsForInference(
                 items=[
                     runners.DatasetItemForInference(
@@ -458,8 +469,6 @@ class LearningDialog(QtWidgets.QDialog):
                 total_frame_count=frame_count,
             )
         elif predict_frames_choice.startswith("suggested"):
-            # For inference on all suggested frames, we'll have a single
-            # inference item.
             items_for_inference = runners.ItemsForInference(
                 items=[
                     runners.DatasetItemForInference(
@@ -469,7 +478,6 @@ class LearningDialog(QtWidgets.QDialog):
                 total_frame_count=frame_count,
             )
         else:
-            # Otherwise, make an inference item for each video with list of frames.
             items_for_inference = runners.ItemsForInference.from_video_frames_dict(
                 frame_selection, total_frame_count=frame_count
             )
@@ -488,24 +496,37 @@ class LearningDialog(QtWidgets.QDialog):
             ]
             if untrained:
                 can_run = False
-                message = f"Cannot run inference with untrained models ({', '.join(untrained)})."
+                message = (
+                    "Cannot run inference with untrained models "
+                    f"({', '.join(untrained)})."
+                )
 
         # Make sure skeleton will be valid for bottom-up inference.
         if self.mode == "training" and self.current_pipeline == "bottom-up":
             skeleton = self.labels.skeletons[0]
 
             if not skeleton.is_arborescence:
-                message += "Cannot run bottom-up pipeline when skeleton is not an arborescence."
+                message += (
+                    "Cannot run bottom-up pipeline when skeleton is not an "
+                    "arborescence."
+                )
 
                 root_names = [n.name for n in skeleton.root_nodes]
                 over_max_in_degree = [n.name for n in skeleton.in_degree_over_one]
                 cycles = skeleton.cycles
 
                 if len(root_names) > 1:
-                    message += f" There are multiple root nodes: {', '.join(root_names)} (there should be exactly one node which is not a target)."
+                    message += (
+                        f" There are multiple root nodes: {', '.join(root_names)} "
+                        "(there should be exactly one node which is not a target)."
+                    )
 
                 if over_max_in_degree:
-                    message += f" There are nodes which are target in multiple edges: {', '.join(over_max_in_degree)} (maximum in-degree should be 1).</li>"
+                    message += (
+                        " There are nodes which are target in multiple edges: "
+                        f"{', '.join(over_max_in_degree)} (maximum in-degree should be "
+                        "1).</li>"
+                    )
 
                 if cycles:
                     cycle_strings = []
@@ -574,26 +595,127 @@ class LearningDialog(QtWidgets.QDialog):
             win.setWindowTitle("Inference Results")
             win.exec_()
 
-    def save(self):
-        models_dir = os.path.join(os.path.dirname(self.labels_filename), "/models")
-        output_dir = FileDialog.openDir(
-            None, directory=models_dir, caption="Select directory to save scripts"
-        )
+    def save(
+        self, output_dir: Optional[str] = None, labels_filename: Optional[str] = None
+    ):
+        """Save scripts and configs to run pipeline."""
+        if output_dir is None:
+            models_dir = os.path.join(os.path.dirname(self.labels_filename), "/models")
+            output_dir = FileDialog.openDir(
+                None, directory=models_dir, caption="Select directory to save scripts"
+            )
 
-        if not output_dir:
-            return
+            if not output_dir:
+                return
 
         pipeline_form_data = self.pipeline_form_widget.get_form_data()
         items_for_inference = self.get_items_for_inference(pipeline_form_data)
         config_info_list = self.get_every_head_config_data(pipeline_form_data)
 
+        if labels_filename is None:
+            labels_filename = self.labels_filename
+
         runners.write_pipeline_files(
             output_dir=output_dir,
-            labels_filename=self.labels_filename,
+            labels_filename=labels_filename,
             config_info_list=config_info_list,
             inference_params=pipeline_form_data,
             items_for_inference=items_for_inference,
         )
+
+    def export_package(self, output_path: Optional[str] = None, gui: bool = True):
+        """Export training job package."""
+        # TODO: Warn if self.mode != "training"?
+        if output_path is None:
+            # Prompt for output path.
+            output_path, _ = FileDialog.save(
+                caption="Export Training Job Package...",
+                dir=f"{self.labels_filename}.training_job.zip",
+                filter="Training Job Package (*.zip)",
+            )
+            if len(output_path) == 0:
+                return
+
+        # Create temp dir before packaging.
+        tmp_dir = tempfile.TemporaryDirectory()
+
+        # Remove the temp dir when program exits in case something goes wrong.
+        # atexit.register(shutil.rmtree, tmp_dir.name, ignore_errors=True)
+
+        # Check if we need to include suggestions.
+        include_suggestions = False
+        items_for_inference = self.get_items_for_inference(
+            self.pipeline_form_widget.get_form_data()
+        )
+        for item in items_for_inference.items:
+            if (
+                isinstance(item, runners.DatasetItemForInference)
+                and item.frame_filter == "suggested"
+            ):
+                include_suggestions = True
+
+        # Save dataset with images.
+        labels_pkg_filename = str(
+            Path(self.labels_filename).with_suffix(".pkg.slp").name
+        )
+        if gui:
+            ret = sleap.gui.commands.export_dataset_gui(
+                self.labels,
+                tmp_dir.name + "/" + labels_pkg_filename,
+                all_labeled=False,
+                suggested=include_suggestions,
+            )
+            if ret == "canceled":
+                # Quit if user canceled during export.
+                tmp_dir.cleanup()
+                return
+        else:
+            self.labels.save(
+                tmp_dir.name + "/" + labels_pkg_filename,
+                with_images=True,
+                embed_all_labeled=False,
+                embed_suggested=include_suggestions,
+            )
+
+        # Save config and scripts.
+        self.save(tmp_dir.name, labels_filename=labels_pkg_filename)
+
+        # Package everything.
+        shutil.make_archive(
+            base_name=str(Path(output_path).with_suffix("")),
+            format="zip",
+            root_dir=tmp_dir.name,
+        )
+
+        msg = f"Saved training job package to: {output_path}"
+        print(msg)
+
+        # Close training editor.
+        self.accept()
+
+        if gui:
+            msgBox = QtWidgets.QMessageBox(text=f"Created training job package:")
+            msgBox.setDetailedText(output_path)
+            msgBox.setWindowTitle("Training Job Package")
+            okButton = msgBox.addButton(QtWidgets.QMessageBox.Ok)
+            openFolderButton = msgBox.addButton(
+                "Open containing folder", QtWidgets.QMessageBox.ActionRole
+            )
+            colabButton = msgBox.addButton(
+                "Go to Colab", QtWidgets.QMessageBox.ActionRole
+            )
+            msgBox.exec_()
+
+            if msgBox.clickedButton() == openFolderButton:
+                sleap.gui.commands.open_file(str(Path(output_path).resolve().parent))
+            elif msgBox.clickedButton() == colabButton:
+                # TODO: Update this to more workflow-tailored notebook.
+                sleap.gui.commands.copy_to_clipboard(output_path)
+                sleap.gui.commands.open_website(
+                    "https://colab.research.google.com/github/murthylab/sleap-notebooks/blob/master/Training_and_inference_using_Google_Drive.ipynb"
+                )
+
+        tmp_dir.cleanup()
 
 
 class TrainingPipelineWidget(QtWidgets.QWidget):

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -284,7 +284,7 @@ class InferenceTask:
                         kill_process(proc.pid)
                         print(f"Killed PID: {proc.pid}")
                         return "", "canceled"
-                time.sleep(0.1)
+                time.sleep(0.05)
 
             print(f"Process return code: {proc.returncode}")
             success = proc.returncode == 0
@@ -647,12 +647,12 @@ def run_gui_inference(
                 progress.setValue(n_processed)
 
             msg = "Predicting..."
-            if current_item is not None and total_items is not None:
-                msg += f" [{current_item + 1}/{total_items}]"
+            # if current_item is not None and total_items is not None:
+            #     msg += f" [{current_item + 1}/{total_items}]"
 
             if n_processed is not None and n_total is not None:
                 prc = (n_processed / n_total) * 100
-                msg += f"\n{n_processed+1}/{n_total} ({prc:.1f}%)"
+                msg += f"       {n_processed+1}/{n_total} (<b>{prc:.1f}%</b>)"
 
             # Show time elapsed?
             if rate is not None and eta is not None:
@@ -662,7 +662,9 @@ def run_gui_inference(
                     eta_str = f"{int(eta_hours)}:{int(eta_mins):02}:{int(eta_secs):02}"
                 else:
                     eta_str = f"{int(eta_mins)}:{int(eta_secs):02}"
-                msg += f"\nETA: {eta_str} ({rate:.1f} FPS)"
+                msg += f"<br>ETA: <b>{eta_str}</b>       FPS: <b>{rate:.1f}</b>"
+                
+            msg = msg.replace(" ", "&nbsp;")
 
             progress.setLabelText(msg)
             QtWidgets.QApplication.instance().processEvents()

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -498,7 +498,8 @@ def run_gui_training(
                 os.path.dirname(labels_filename), "models"
             )
             training.setup_new_run_folder(
-                job.outputs, base_run_name=f"{model_type}.{len(labels)}"
+                job.outputs,
+                base_run_name=f"{model_type}.n={len(labels.user_labeled_frames)}",
             )
 
             if gui:
@@ -619,8 +620,6 @@ def train_subprocess(
     save_viz: bool = False,
 ):
     """Runs training inside subprocess."""
-
-    # run_name = job_config.outputs.run_name
     run_path = job_config.outputs.run_path
 
     success = False

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -241,6 +241,8 @@ class InferenceTask:
         if gui:
             cli_args.extend(("--verbosity", "json"))
 
+        cli_args.extend(("--no-empty-frames",))
+
         return cli_args, output_path
 
     def predict_subprocess(
@@ -651,8 +653,9 @@ def run_gui_inference(
             #     msg += f" [{current_item + 1}/{total_items}]"
 
             if n_processed is not None and n_total is not None:
+
                 prc = (n_processed / n_total) * 100
-                msg += f"       {n_processed+1}/{n_total} (<b>{prc:.1f}%</b>)"
+                msg = f"Predicted: {n_processed+1}/{n_total} (<b>{prc:.1f}%</b>)"
 
             # Show time elapsed?
             if rate is not None and eta is not None:
@@ -663,7 +666,7 @@ def run_gui_inference(
                 else:
                     eta_str = f"{int(eta_mins)}:{int(eta_secs):02}"
                 msg += f"<br>ETA: <b>{eta_str}</b>       FPS: <b>{rate:.1f}</b>"
-                
+
             msg = msg.replace(" ", "&nbsp;")
 
             progress.setLabelText(msg)

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -684,7 +684,7 @@ def run_gui_inference(
             waiting_callback=waiting_item,
             gui=gui,
         )
-        
+
         if gui:
             progress.close()
 
@@ -701,7 +701,7 @@ def run_gui_inference(
                         "terminal may have more information about the error."
                     )
                 ).exec_()
-            return -1    
+            return -1
 
 
 def train_subprocess(

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -760,7 +760,7 @@ def train_subprocess(
                 ret = waiting_callback()
                 if ret == "cancel":
                     print("Canceling training...")
-                    kill_process(proc)
+                    kill_process(proc.pid)
                     print(f"Killed PID: {proc.pid}")
                     return run_path, "canceled"
             time.sleep(0.1)

--- a/sleap/gui/overlays/instance.py
+++ b/sleap/gui/overlays/instance.py
@@ -43,7 +43,9 @@ class InstanceOverlay(BaseOverlay):
         has_user = any((True for inst in instances if not hasattr(inst, "score")))
 
         for instance in instances:
-            self.player.addInstance(instance=instance)
+            self.player.addInstance(
+                instance=instance, markerRadius=self.state.get("marker size", 4)
+            )
 
         self.player.showLabels(self.state.get("show labels", default=True))
         self.player.showEdges(self.state.get("show edges", default=True))

--- a/sleap/gui/shortcuts.py
+++ b/sleap/gui/shortcuts.py
@@ -3,9 +3,7 @@ Class for accessing/setting keyboard shortcuts.
 """
 
 from typing import Dict, Union
-
 from PySide2.QtGui import QKeySequence
-
 from sleap import util
 
 
@@ -99,6 +97,11 @@ class Shortcuts(object):
             data[key] = val.toString() if isinstance(val, QKeySequence) else val
 
         util.save_config_yaml("shortcuts.yaml", data)
+
+    def reset_to_default(self):
+        """Reset shortcuts to default and save."""
+        self._shortcuts = util.get_config_yaml("shortcuts.yaml", get_defaults=True)
+        self.save()
 
     def __getitem__(self, idx: Union[slice, int, str]) -> Union[str, Dict[str, str]]:
         """

--- a/sleap/instance.py
+++ b/sleap/instance.py
@@ -1609,6 +1609,10 @@ class LabeledFrame:
         """Return the image for this frame of shape (height, width, channels)."""
         return self.video.get_frame(self.frame_idx)
 
+    def numpy(self) -> np.ndarray:
+        """Return the instances as an array of shape (instances, nodes, 2)."""
+        return np.stack([inst.numpy() for inst in self.instances], axis=0)
+
     def plot(self, image: bool = True, scale: float = 1.0):
         """Plot the frame with all instances.
 

--- a/sleap/instance.py
+++ b/sleap/instance.py
@@ -1609,34 +1609,36 @@ class LabeledFrame:
         """Return the image for this frame of shape (height, width, channels)."""
         return self.video.get_frame(self.frame_idx)
 
-    def plot(self, image: bool = True):
+    def plot(self, image: bool = True, scale: float = 1.0):
         """Plot the frame with all instances.
 
         Args:
             image: If False, only the instances will be plotted without loading the
                 original image.
+            scale: Relative scaling for the figure.
 
         Notes:
-            See sleap.nn.viz.plot_img and sleap.nn.viz.plot_instances for more plotting
-            options.
+            See `sleap.nn.viz.plot_img` and `sleap.nn.viz.plot_instances` for more
+            plotting options.
         """
         if image:
-            sleap.nn.viz.plot_img(self.image)
+            sleap.nn.viz.plot_img(self.image, scale=scale)
         sleap.nn.viz.plot_instances(self.instances)
 
-    def plot_predicted(self, image: bool = True):
+    def plot_predicted(self, image: bool = True, scale: float = 1.0):
         """Plot the frame with all predicted instances.
 
         Args:
             image: If False, only the instances will be plotted without loading the
                 original image.
+            scale: Relative scaling for the figure.
 
         Notes:
-            See sleap.nn.viz.plot_img and sleap.nn.viz.plot_instances for more plotting
-            options.
+            See `sleap.nn.viz.plot_img` and `sleap.nn.viz.plot_instances` for more
+            plotting options.
         """
         if image:
-            sleap.nn.viz.plot_img(self.image)
+            sleap.nn.viz.plot_img(self.image, scale=scale)
         sleap.nn.viz.plot_instances(
             self.predicted_instances,
             color_by_track=(len(self.predicted_instances) > 0)

--- a/sleap/instance.py
+++ b/sleap/instance.py
@@ -883,10 +883,7 @@ class Instance:
 
     @classmethod
     def from_pointsarray(
-        cls,
-        points: np.ndarray,
-        skeleton: Skeleton,
-        track: Optional[Track] = None,
+        cls, points: np.ndarray, skeleton: Skeleton, track: Optional[Track] = None
     ) -> "Instance":
         """Create an instance from an array of points.
 
@@ -912,10 +909,7 @@ class Instance:
 
     @classmethod
     def from_numpy(
-        cls,
-        points: np.ndarray,
-        skeleton: Skeleton,
-        track: Optional[Track] = None,
+        cls, points: np.ndarray, skeleton: Skeleton, track: Optional[Track] = None
     ) -> "Instance":
         """Create an instance from a numpy array.
 
@@ -1289,9 +1283,7 @@ class LabeledFrame:
     @property
     def user_instances(self) -> List[Instance]:
         """Return list of user instances associated with this frame."""
-        return [
-            inst for inst in self._instances if type(inst) == Instance
-        ]
+        return [inst for inst in self._instances if type(inst) == Instance]
 
     @property
     def training_instances(self) -> List[Instance]:

--- a/sleap/instance.py
+++ b/sleap/instance.py
@@ -375,8 +375,7 @@ class Instance:
     def _validate_from_predicted_(
         self, attribute, from_predicted: Optional["PredictedInstance"]
     ):
-        """
-        Validation method called by attrs.
+        """Validation method called by attrs.
 
         Checks that from_predicted is None or :class:`PredictedInstance`
 
@@ -397,8 +396,7 @@ class Instance:
 
     @_points.validator
     def _validate_all_points(self, attribute, points: Union[dict, PointArray]):
-        """
-        Validation method called by attrs.
+        """Validation method called by attrs.
 
         Checks that all the _points defined for the skeleton are found
         in the skeleton.
@@ -431,8 +429,7 @@ class Instance:
                 )
 
     def __attrs_post_init__(self):
-        """
-        Method called by attrs after __init__()
+        """Method called by attrs after __init__().
 
         Initializes points if none were specified when creating object,
         caches list of nodes so what we can still find points in array
@@ -443,12 +440,8 @@ class Instance:
 
         Raises:
             ValueError: If object has no `Skeleton`.
-
-        Returns:
-            None
         """
-
-        if not self.skeleton:
+        if self.skeleton is None:
             raise ValueError("No skeleton set for Instance")
 
         # If the user did not pass a points list initialize a point array for future
@@ -474,8 +467,7 @@ class Instance:
     def _points_dict_to_array(
         points: Dict[Union[str, Node], Point], parray: PointArray, skeleton: Skeleton
     ):
-        """
-        Sets values in given :class:`PointsArray` from dictionary.
+        """Set values in given :class:`PointsArray` from dictionary.
 
         Args:
             points: The dictionary of points. Keys can be either node
@@ -487,11 +479,7 @@ class Instance:
         Raises:
             ValueError: If dictionary keys are not either all strings
                 or all :class:`Node`s.
-
-        Returns:
-            None
         """
-
         # Check if the dict contains all strings
         is_string_dict = set(map(type, points)) == {str}
 
@@ -524,8 +512,7 @@ class Instance:
                 pass
 
     def _node_to_index(self, node: Union[str, Node]) -> int:
-        """
-        Helper method to get the index of a node from its name.
+        """Helper method to get the index of a node from its name.
 
         Args:
             node: Node name or :class:`Node` object.
@@ -539,8 +526,7 @@ class Instance:
         self,
         node: Union[List[Union[str, Node, int]], Union[str, Node, int], np.ndarray],
     ) -> Union[List[Point], Point, np.ndarray]:
-        """
-        Get the Points associated with particular skeleton node(s).
+        """Get the Points associated with particular skeleton node(s).
 
         Args:
             node: A single node or list of nodes within the skeleton
@@ -577,8 +563,7 @@ class Instance:
         return self._points[node]
 
     def __contains__(self, node: Union[str, Node, int]) -> bool:
-        """
-        Whether this instance has a point with the specified node.
+        """Whether this instance has a point with the specified node.
 
         Args:
             node: Node name or :class:`Node` object.
@@ -604,8 +589,7 @@ class Instance:
         node: Union[List[Union[str, Node, int]], Union[str, Node, int], np.ndarray],
         value: Union[List[Point], Point, np.ndarray],
     ):
-        """
-        Set the point(s) for given node(s).
+        """Set the point(s) for given node(s).
 
         Args:
             node: Either node (by name or `Node`) or list of nodes.
@@ -615,9 +599,6 @@ class Instance:
             IndexError: If lengths of lists don't match, or if exactly
                 one of the inputs is a list.
             KeyError: If skeleton does not have (one of) the node(s).
-
-        Returns:
-            None
         """
         # Make sure node and value, if either are lists, are of compatible size
         if isinstance(node, (list, np.ndarray)):
@@ -649,8 +630,7 @@ class Instance:
             self._points[node_idx] = value
 
     def __delitem__(self, node: Union[str, Node]):
-        """
-        Delete node key and points associated with that node.
+        """Delete node key and points associated with that node.
 
         Args:
             node: Node name or :class:`Node` object.
@@ -671,7 +651,7 @@ class Instance:
             )
 
     def __repr__(self) -> str:
-        """String representation of this object."""
+        """Return string representation of this object."""
         pts = []
         for node, pt in self.nodes_points:
             pts.append(f"{node.name}: ({pt.x:.1f}, {pt.y:.1f})")
@@ -687,8 +667,7 @@ class Instance:
         )
 
     def matches(self, other: "Instance") -> bool:
-        """
-        Whether two instances match by value.
+        """Whether two instances match by value.
 
         Checks the types, points, track, and frame index.
 
@@ -721,9 +700,7 @@ class Instance:
 
     @property
     def nodes(self) -> Tuple[Node, ...]:
-        """
-        The tuple of nodes that have been labelled for this instance.
-        """
+        """Return nodes that have been labelled for this instance."""
         self._fix_array()
         return tuple(
             self._nodes[i]
@@ -733,32 +710,23 @@ class Instance:
 
     @property
     def nodes_points(self) -> List[Tuple[Node, Point]]:
-        """
-        The list of (node, point) tuples for all labeled points.
-        """
+        """Return a list of (node, point) tuples for all labeled points."""
         names_to_points = dict(zip(self.nodes, self.points))
         return names_to_points.items()
 
     @property
     def points(self) -> Tuple[Point, ...]:
-        """
-        The tuple of labelled points, in order they were labelled.
-        """
+        """Return a tuple of labelled points, in the order they were labelled."""
         self._fix_array()
         return tuple(point for point in self._points if not point.isnan())
 
     def _fix_array(self):
-        """
-        Fixes PointArray after nodes have been added or removed.
+        """Fix PointArray after nodes have been added or removed.
 
         This updates the PointArray as required by comparing the cached
         list of nodes to the nodes in the `Skeleton` object (which may
         have changed).
-
-        Returns:
-            None
         """
-
         # Check if cached skeleton nodes are different than current nodes
         if self._nodes != self.skeleton.nodes:
             # Create new PointArray (or PredictedPointArray)
@@ -777,8 +745,7 @@ class Instance:
     def get_points_array(
         self, copy: bool = True, invisible_as_nan: bool = False, full: bool = False
     ) -> Union[np.ndarray, np.recarray]:
-        """
-        Return the instance's points in array form.
+        """Return the instance's points in array form.
 
         Args:
             copy: If True, the return a copy of the points array as an ndarray.
@@ -821,14 +788,13 @@ class Instance:
 
     @property
     def points_array(self) -> np.ndarray:
-        """
-        Nx2 array of x and y for visible points.
+        """Return array of x and y coordinates for visible points.
 
-        Row in array corresponds to order of points in skeleton.
-        Invisible points will have nans.
+        Row in array corresponds to order of points in skeleton. Invisible points will
+        be denoted by NaNs.
 
         Returns:
-            ndarray of visible point coordinates.
+            A numpy array of of shape `(n_nodes, 2)` point coordinates.
         """
         return self.get_points_array(invisible_as_nan=True)
 
@@ -838,13 +804,19 @@ class Instance:
         Alias for `points_array`.
 
         Returns:
-            Array of shape (n_nodes, 2) of dtype float32 containing the coordinates of
-            the instance's nodes. Missing/not visible nodes will be replaced with NaNs.
+            Array of shape `(n_nodes, 2)` of dtype `float32` containing the coordinates
+            of the instance's nodes. Missing/not visible nodes will be replaced with
+            `NaN`.
         """
         return self.points_array
 
     def transform_points(self, transformation_matrix):
-        """Applies transformation matrix to points."""
+        """Apply affine transformation matrix to points in the instance.
+
+        Args:
+            transformation_matrix: Affine transformation matrix as a numpy array of
+                shape `(3, 3)`.
+        """
         points = self.get_points_array(copy=True, full=False, invisible_as_nan=False)
 
         if transformation_matrix.shape[1] == 3:
@@ -861,14 +833,18 @@ class Instance:
 
     @property
     def centroid(self) -> np.ndarray:
-        """Returns instance centroid as (x,y) numpy row vector."""
+        """Return instance centroid as an array of `(x, y)` coordinates
+
+        Notes:
+            This computes the centroid as the median of the visible points.
+        """
         points = self.points_array
         centroid = np.nanmedian(points, axis=0)
         return centroid
 
     @property
     def bounding_box(self) -> np.ndarray:
-        """Returns the instance's containing bounding box in [y1, x1, y2, x2] format."""
+        """Return bounding box containing all points in `[y1, x1, y2, x2]` format."""
         points = self.points_array
         bbox = np.concatenate(
             [np.nanmin(points, axis=0)[::-1], np.nanmax(points, axis=0)[::-1]]
@@ -876,13 +852,19 @@ class Instance:
         return bbox
 
     @property
+    def midpoint(self) -> np.ndarray:
+        """Return the center of the bounding box of the instance points."""
+        y1, x1, y2, x2 = self.bounding_box
+        return np.array([(x2 - x1) / 2, (y2 - y1) / 2])
+
+    @property
     def n_visible_points(self) -> int:
-        """Returns the count of points that are visible in this instance."""
+        """Return the count of points that are visible in this instance."""
         return sum(~np.isnan(self.points_array[:, 0]))
 
     @property
     def video(self) -> Optional[Video]:
-        """The video of the labeled frame this instance is associated with."""
+        """Return the video of the labeled frame this instance is associated with."""
         if self.frame is None:
             return None
         else:
@@ -890,7 +872,7 @@ class Instance:
 
     @property
     def frame_idx(self) -> Optional[int]:
-        """The frame index of the labeled frame this instance is associated with."""
+        """Return the index of the labeled frame this instance is associated with."""
         if self.frame is None:
             return None
         else:
@@ -903,7 +885,7 @@ class Instance:
         skeleton: Skeleton,
         track: Optional[Track] = None,
     ) -> "Instance":
-        """Create an instance from pointsarray.
+        """Create an instance from an array of points.
 
         Args:
             points: A numpy array of shape `(n_nodes, 2)` and dtype `float32` that
@@ -974,7 +956,7 @@ class PredictedInstance(Instance):
             raise ValueError("PredictedInstance should not have from_predicted.")
 
     def __repr__(self) -> str:
-        """String representation of this object."""
+        """Return string representation of this object."""
         pts = []
         for node, pt in self.nodes_points:
             pts.append(f"{node.name}: ({pt.x:.1f}, {pt.y:.1f}, {pt.score:.2f})")
@@ -993,14 +975,12 @@ class PredictedInstance(Instance):
 
     @property
     def points_and_scores_array(self) -> np.ndarray:
-        """
-        (N, 3) array of (x, y, score) for predicted points.
+        """Return the instance points and scores as an array.
 
-        Row in arrow corresponds to order of points in skeleton.
-        Invisible points will have NaNs.
+        This will be a `(n_nodes, 3)` array of `(x, y, score)` for each predicted point.
 
-        Returns:
-            ndarray of visible point coordinates and scores.
+        Rows in the array correspond to the order of points in skeleton. Invisible
+        points will be represented as NaNs.
         """
         pts = self.get_points_array(full=True, copy=True, invisible_as_nan=True)
         return pts[:, (0, 1, 4)]  # (x, y, score)
@@ -1012,19 +992,18 @@ class PredictedInstance(Instance):
 
     @classmethod
     def from_instance(cls, instance: Instance, score: float) -> "PredictedInstance":
-        """
-        Create a :class:`PredictedInstance` from an :class:`Instance`.
+        """Create a `PredictedInstance` from an `Instance`.
 
-        The fields are copied in a shallow manner with the exception of
-        points. For each point in the instance a :class:`PredictedPoint`
-        is created with score set to default value.
+        The fields are copied in a shallow manner with the exception of points. For each
+        point in the instance a `PredictedPoint` is created with score set to default
+        value.
 
         Args:
-            instance: The Instance object to shallow copy data from.
+            instance: The `Instance` object to shallow copy data from.
             score: The score for this instance.
 
         Returns:
-            A PredictedInstance for the given Instance.
+            A `PredictedInstance` for the given `Instance`.
         """
         kw_args = attr.asdict(
             instance,
@@ -1047,11 +1026,11 @@ class PredictedInstance(Instance):
         """Create a predicted instance from data arrays.
 
         Args:
-            points: A numpy array of shape (n_nodes, 2) and dtype float32 that contains
-                the points in (x, y) coordinates of each node. Missing nodes should be
-                represented as NaNs.
-            point_confidences: A numpy array of shape (n_nodes,) and dtype float32 that
-                contains the confidence/score of the points.
+            points: A numpy array of shape `(n_nodes, 2)` and dtype `float32` that
+                contains the points in `(x, y)` coordinates of each node. Missing nodes
+                should be represented as `NaN`.
+            point_confidences: A numpy array of shape `(n_nodes,)` and dtype `float32`
+                that contains the confidence/score of the points.
             instance_score: Scalar float representing the overall instance score, e.g.,
                 the PAF grouping score.
             skeleton: A sleap.Skeleton instance with n_nodes nodes to associate with the
@@ -1081,18 +1060,15 @@ class PredictedInstance(Instance):
 
 
 def make_instance_cattr() -> cattr.Converter:
-    """
-    Create a cattr converter for Lists of Instances/PredictedInstances.
+    """Create a cattr converter for Lists of Instances/PredictedInstances.
 
-    This is required because cattrs doesn't automatically detect the
-    class when the attributes of one class are a subset of another.
+    This is required because cattrs doesn't automatically detect the class when the
+    attributes of one class are a subset of another.
 
     Returns:
-        A cattr converter with hooks registered for structuring and
-            unstructuring :class:`Instance` objects and
-            :class:`PredictedInstance`s.
+        A cattr converter with hooks registered for structuring and unstructuring
+        `Instance` and `PredictedInstance` objects.
     """
-
     converter = cattr.Converter()
 
     #### UNSTRUCTURE HOOKS

--- a/sleap/instance.py
+++ b/sleap/instance.py
@@ -343,8 +343,7 @@ class Track:
 
 @attr.s(eq=False, order=False, slots=True, repr=False, str=False)
 class Instance:
-    """
-    The class :class:`Instance` represents a labelled instance of a skeleton.
+    """This class represents a labeled instance.
 
     Args:
         skeleton: The skeleton that this instance is associated with.
@@ -859,8 +858,12 @@ class Instance:
 
     @property
     def n_visible_points(self) -> int:
-        """Return the count of points that are visible in this instance."""
+        """Return the number of visible points in this instance."""
         return sum(~np.isnan(self.points_array[:, 0]))
+
+    def __len__(self) -> int:
+        """Return the number of visible points in this instance."""
+        return self.n_visible_points
 
     @property
     def video(self) -> Optional[Video]:

--- a/sleap/instance.py
+++ b/sleap/instance.py
@@ -887,7 +887,7 @@ class Instance:
             return None
         else:
             return self.frame.video
-    
+
     @property
     def frame_idx(self) -> Optional[int]:
         """The frame index of the labeled frame this instance is associated with."""

--- a/sleap/instance.py
+++ b/sleap/instance.py
@@ -1152,12 +1152,12 @@ def make_instance_cattr() -> cattr.Converter:
 
 @attr.s(auto_attribs=True, eq=False, repr=False, str=False)
 class LabeledFrame:
-    """
-    Holds labeled data for a single frame of a video.
+    """Holds labeled data for a single frame of a video.
 
     Args:
         video: The :class:`Video` associated with this frame.
         frame_idx: The index of frame in video.
+        instances: List of instances associated with the frame.
     """
 
     video: Video = attr.ib()
@@ -1167,8 +1167,7 @@ class LabeledFrame:
     )
 
     def __attrs_post_init__(self):
-        """
-        Called by attrs.
+        """Called by attrs.
 
         Updates :attribute:`Instance.frame` for each instance associated
         with this :class:`LabeledFrame`.
@@ -1179,19 +1178,19 @@ class LabeledFrame:
             instance.frame = self
 
     def __len__(self) -> int:
-        """Returns number of instances associated with frame."""
+        """Return number of instances associated with frame."""
         return len(self.instances)
 
     def __getitem__(self, index) -> Instance:
-        """Returns instance (retrieved by index)."""
+        """Return instance (retrieved by index)."""
         return self.instances.__getitem__(index)
 
     def index(self, value: Instance) -> int:
-        """Returns index of given :class:`Instance`."""
+        """Return index of given :class:`Instance`."""
         return self.instances.index(value)
 
     def __delitem__(self, index):
-        """Removes instance (by index) from frame."""
+        """Remove instance (by index) from frame."""
         value = self.instances.__getitem__(index)
 
         self.instances.__delitem__(index)
@@ -1209,8 +1208,7 @@ class LabeledFrame:
         )
 
     def insert(self, index: int, value: Instance):
-        """
-        Adds instance to frame.
+        """Add instance to frame.
 
         Args:
             index: The index in list of frame instances where we should
@@ -1226,8 +1224,7 @@ class LabeledFrame:
         value.frame = self
 
     def __setitem__(self, index, value: Instance):
-        """
-        Sets nth instance in frame to the given instance.
+        """Set nth instance in frame to the given instance.
 
         Args:
             index: The index of instance to replace with new instance.
@@ -1244,8 +1241,7 @@ class LabeledFrame:
     def find(
         self, track: Optional[Union[Track, int]] = -1, user: bool = False
     ) -> List[Instance]:
-        """
-        Retrieves instances (if any) matching specifications.
+        """Retrieve instances (if any) matching specifications.
 
         Args:
             track: The :class:`Track` to match. Note that None will only
@@ -1265,13 +1261,12 @@ class LabeledFrame:
 
     @property
     def instances(self) -> List[Instance]:
-        """Returns list of all instances associated with this frame."""
+        """Return list of all instances associated with this frame."""
         return self._instances
 
     @instances.setter
     def instances(self, instances: List[Instance]):
-        """
-        Sets the list of instances associated with this frame.
+        """Set the list of instances associated with this frame.
 
         Updates the `frame` attribute on each instance to the
         :class:`LabeledFrame` which will contain the instance.
@@ -1293,14 +1288,14 @@ class LabeledFrame:
 
     @property
     def user_instances(self) -> List[Instance]:
-        """Returns list of user instances associated with this frame."""
+        """Return list of user instances associated with this frame."""
         return [
-            inst for inst in self._instances if not isinstance(inst, PredictedInstance)
+            inst for inst in self._instances if type(inst) == Instance
         ]
 
     @property
     def training_instances(self) -> List[Instance]:
-        """Returns list of user instances with points for training."""
+        """Return list of user instances with points for training."""
         return [
             inst
             for inst in self._instances
@@ -1309,23 +1304,22 @@ class LabeledFrame:
 
     @property
     def predicted_instances(self) -> List[PredictedInstance]:
-        """Returns list of predicted instances associated with frame."""
-        return [inst for inst in self._instances if isinstance(inst, PredictedInstance)]
+        """Return list of predicted instances associated with frame."""
+        return [inst for inst in self._instances if type(inst) == PredictedInstance]
 
     @property
     def has_user_instances(self) -> bool:
-        """Whether the frame contains any user instances."""
+        """Return whether the frame contains any user instances."""
         return len(self.user_instances) > 0
 
     @property
     def has_predicted_instances(self) -> bool:
-        """Whether the frame contains any predicted instances."""
+        """Return whether the frame contains any predicted instances."""
         return len(self.predicted_instances) > 0
 
     @property
     def unused_predictions(self) -> List[Instance]:
-        """
-        Returns list of "unused" :class:`PredictedInstance` objects in frame.
+        """Return a list of "unused" :class:`PredictedInstance` objects in frame.
 
         This is all the :class:`PredictedInstance` objects which do not have
         a corresponding :class:`Instance` in the same track in frame.
@@ -1363,8 +1357,7 @@ class LabeledFrame:
 
     @property
     def instances_to_show(self) -> List[Instance]:
-        """
-        Return a list of instances to show in GUI for this frame.
+        """Return a list of instances to show in GUI for this frame.
 
         This list will not include any predicted instances for which
         there's a corresponding regular instance.
@@ -1389,7 +1382,7 @@ class LabeledFrame:
     def merge_frames(
         labeled_frames: List["LabeledFrame"], video: "Video", remove_redundant=True
     ) -> List["LabeledFrame"]:
-        """Merged LabeledFrames for same video and frame index.
+        """Return merged LabeledFrames for same video and frame index.
 
         Args:
             labeled_frames: List of :class:`LabeledFrame` objects to merge.
@@ -1437,8 +1430,7 @@ class LabeledFrame:
     def complex_merge_between(
         cls, base_labels: "Labels", new_frames: List["LabeledFrame"]
     ) -> Tuple[Dict[Video, Dict[int, List[Instance]]], List[Instance], List[Instance]]:
-        """
-        Merge data from new frames into a :class:`Labels` object.
+        """Merge data from new frames into a :class:`Labels` object.
 
         Everything that can be merged cleanly is merged, any conflicts
         are returned.
@@ -1491,8 +1483,7 @@ class LabeledFrame:
     def complex_frame_merge(
         cls, base_frame: "LabeledFrame", new_frame: "LabeledFrame"
     ) -> Tuple[List[Instance], List[Instance], List[Instance]]:
-        """
-        Merge two frames, return conflicts if any.
+        """Merge two frames, return conflicts if any.
 
         A conflict occurs when
         * each frame has Instances which don't perfectly match those

--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -1891,7 +1891,6 @@ class Labels(MutableSequence):
                 ret = progress_callback(n, n_total)
                 if ret == False:
                     vid.close()
-                    os.remove(output_path)
                     return []
 
             vid.close()

--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -699,6 +699,34 @@ class Labels(MutableSequence):
         except KeyError:
             return None
 
+    def extract(self, inds) -> "Labels":
+        """Extract labeled frames from indices and return a new `Labels` object.
+
+        Args:
+            inds: Any valid indexing keys, e.g., a range, slice, list of label indices,
+                numpy array, `Video`, etc. See `__getitem__` for full list.
+
+        Returns:
+            A new `Labels` object with the specified labeled frames.
+
+            This will preserve the other data structures even if they are not found in
+            the extracted labels, including:
+                - `Labels.videos`
+                - `Labels.skeletons`
+                - `Labels.tracks`
+                - `Labels.suggestions`
+                - `Labels.provenance`
+        """
+        lfs = self.__getitem__(inds)
+        new_labels = type(self)(
+            labeled_frames=lfs,
+            videos=self.videos,
+            skeletons=self.skeletons,
+            tracks=self.tracks,
+            suggestions=self.suggestions,
+            provenance=self.provenance,
+        )
+
     def __setitem__(self, index, value: LabeledFrame):
         """Set labeled frame at given index."""
         # TODO: Maybe we should remove this method altogether?

--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -381,7 +381,6 @@ class LabelsDataCache:
                 self._frame_count_cache[None][type_key].discard(idx_pair)
 
 
-
 @attr.s(auto_attribs=True, repr=False, str=False)
 class Labels(MutableSequence):
     """

--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -894,7 +894,9 @@ class Labels(MutableSequence):
         print(f"Suggestions: {len(self.suggestions):,}")
         print("Provenance:", self.provenance)
 
-    def instances(self, video: Video = None, skeleton: Skeleton = None):
+    def instances(
+        self, video: Optional[Video] = None, skeleton: Optional[Skeleton] = None
+    ):
         """Iterate over instances in the labels, optionally with filters.
 
         Args:
@@ -1104,7 +1106,7 @@ class Labels(MutableSequence):
         Args:
             video: `sleap.Video` instance of the suggestion.
             frame_idx: Index of the frame of the suggestion.
-        """ 
+        """
         for suggestion in self.suggestions:
             if suggestion.video == video and suggestion.frame_idx == frame_idx:
                 self.suggestions.remove(suggestion)
@@ -1681,6 +1683,28 @@ class Labels(MutableSequence):
             suggested=embed_suggested,
         )
 
+    def export(self, filename: str):
+        """Export labels to analysis HDF5 format.
+
+        This expects the labels to contain data for a single video (e.g., predictions).
+        
+        Args:
+            filename: Path to output HDF5 file.
+
+        Notes:
+            This will write the contents of the labels out as a HDF5 file without
+            complete metadata.
+
+            The resulting file will have datasets:
+                - `/node_names`: List of skeleton node names.
+                - `/track_names`: List of track names.
+                - `/tracks`: All coordinates of the instances in the labels.
+                - `/track_occupancy`: Mask denoting which instances are present in each
+                    frame.
+        """
+        from sleap.io.format.sleap_analysis import SleapAnalysisAdaptor
+        SleapAnalysisAdaptor.write(filename, self)
+
     @classmethod
     def load_json(cls, filename: str, *args, **kwargs) -> "Labels":
         from .format import read
@@ -2014,7 +2038,7 @@ def load_file(
     filename: Text,
     detect_videos: bool = True,
     search_paths: Optional[Union[List[Text], Text]] = None,
-    match_to: Optional[Labels] = None
+    match_to: Optional[Labels] = None,
 ) -> Labels:
     """Load a SLEAP labels file.
 

--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -875,8 +875,8 @@ class Labels(MutableSequence):
 
     def describe(self):
         """Print basic statistics about the labels dataset."""
-        print("Skeleton:", self.skeleton)
-        print(f"Videos: {len(self.videos)}")
+        print(f"Skeleton: {self.skeleton}")
+        print(f"Videos: {[v.filename for v in self.videos]}")
         n_user = 0
         n_pred = 0
         n_user_inst = 0
@@ -891,7 +891,7 @@ class Labels(MutableSequence):
         print(f"Frames (user/predicted): {n_user:,}/{n_pred:,}")
         print(f"Instances (user/predicted): {n_user_inst:,}/{n_pred_inst:,}")
         print("Tracks:", self.tracks)
-        print(f"Suggestions: {len(self.suggestions)}")
+        print(f"Suggestions: {len(self.suggestions):,}")
         print("Provenance:", self.provenance)
 
     def instances(self, video: Video = None, skeleton: Skeleton = None):

--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -726,6 +726,7 @@ class Labels(MutableSequence):
             suggestions=self.suggestions,
             provenance=self.provenance,
         )
+        return new_labels
 
     def __setitem__(self, index, value: LabeledFrame):
         """Set labeled frame at given index."""
@@ -887,6 +888,10 @@ class Labels(MutableSequence):
     def user_labeled_frame_inds(self) -> List[int]:
         """Return a list of indices of frames with user labeled instances."""
         return [i for i, lf in enumerate(self.labeled_frames) if lf.has_user_instances]
+
+    def with_user_labels_only(self) -> "Labels":
+        """Return a new `Labels` object with only user labels."""
+        return self.extract(self.user_labeled_frame_inds)
 
     def get_labeled_frame_count(self, video: Optional[Video] = None, filter: Text = ""):
         return self._cache.get_frame_count(video, filter)

--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -1718,6 +1718,18 @@ class Labels(MutableSequence):
         return read(filename, for_object="labels", as_format="deeplabcut")
 
     @classmethod
+    def load_deeplabcut_folder(cls, filename: str) -> "Labels":
+        csv_files = glob(f"{filename}/*/*.csv")
+        merged_labels = None
+        for csv_file in csv_files:
+            labels = cls.load_file(csv_file, as_format="deeplabcut")
+            if merged_labels is None:
+                merged_labels = labels
+            else:
+                merged_labels.extend_from(labels, unify=True)
+        return merged_labels
+
+    @classmethod
     def load_coco(
         cls, filename: str, img_dir: str, use_missing_gui: bool = False
     ) -> "Labels":

--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -51,7 +51,7 @@ from typing import (
     Iterable,
     Any,
     Set,
-    Callable
+    Callable,
 )
 
 import attr
@@ -1826,7 +1826,7 @@ class Labels(MutableSequence):
         user_labeled: bool = True,
         all_labeled: bool = False,
         suggested: bool = False,
-        progress_callback: Optional[Callable[[int, int], None]] = None
+        progress_callback: Optional[Callable[[int, int], None]] = None,
     ) -> List[HDF5Video]:
         """Write images for labeled frames from all videos to hdf5 file.
 

--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -412,7 +412,7 @@ class Labels(MutableSequence):
     skeletons: List[Skeleton] = attr.ib(default=attr.Factory(list))
     nodes: List[Node] = attr.ib(default=attr.Factory(list))
     tracks: List[Track] = attr.ib(default=attr.Factory(list))
-    suggestions: List["SuggestionFrame"] = attr.ib(default=attr.Factory(list))
+    suggestions: List[SuggestionFrame] = attr.ib(default=attr.Factory(list))
     negative_anchors: Dict[Video, list] = attr.ib(default=attr.Factory(dict))
     provenance: Dict[Text, Union[str, int, float, bool]] = attr.ib(
         default=attr.Factory(dict)
@@ -1085,6 +1085,30 @@ class Labels(MutableSequence):
             and (frame_range is None or lf.frame_idx in frame_range)
         ]
         return track_frame_inst
+
+    def add_suggestion(self, video: Video, frame_idx: int):
+        """Add a suggested frame to the labels.
+
+        Args:
+            video: `sleap.Video` instance of the suggestion.
+            frame_idx: Index of the frame of the suggestion.
+        """
+        for suggestion in self.suggestions:
+            if suggestion.video == video and suggestion.frame_idx == frame_idx:
+                return
+        self.suggestions.append(SuggestionFrame(video=video, frame_idx=frame_idx))
+
+    def remove_suggestion(self, video: Video, frame_idx: int):
+        """Remove a suggestion from the list by video and frame index.
+
+        Args:
+            video: `sleap.Video` instance of the suggestion.
+            frame_idx: Index of the frame of the suggestion.
+        """ 
+        for suggestion in self.suggestions:
+            if suggestion.video == video and suggestion.frame_idx == frame_idx:
+                self.suggestions.remove(suggestion)
+                return
 
     def get_video_suggestions(
         self, video: Video, user_labeled: bool = True

--- a/sleap/io/format/hdf5.py
+++ b/sleap/io/format/hdf5.py
@@ -225,6 +225,7 @@ class LabelsV1Adaptor(format.adaptor.Adaptor):
         frame_data_format: str = "png",
         all_labeled: bool = False,
         suggested: bool = False,
+        progress_callback: Optional[Callable[[int, int], None]] = None
     ):
 
         labels = source_object
@@ -245,6 +246,7 @@ class LabelsV1Adaptor(format.adaptor.Adaptor):
                 user_labeled=True,
                 all_labeled=all_labeled,
                 suggested=suggested,
+                progress_callback=progress_callback,
             )
 
             # Replace path to video file with "." (which indicates that the

--- a/sleap/io/format/hdf5.py
+++ b/sleap/io/format/hdf5.py
@@ -225,7 +225,7 @@ class LabelsV1Adaptor(format.adaptor.Adaptor):
         frame_data_format: str = "png",
         all_labeled: bool = False,
         suggested: bool = False,
-        progress_callback: Optional[Callable[[int, int], None]] = None
+        progress_callback: Optional[Callable[[int, int], None]] = None,
     ):
 
         labels = source_object

--- a/sleap/io/video.py
+++ b/sleap/io/video.py
@@ -982,7 +982,13 @@ class Video:
 
     def __str__(self) -> str:
         """Informal string representation (for print or format)."""
-        return type(self).__name__ + " ([%d x %d x %d x %d])" % self.shape
+        return (
+            "Video("
+            f"filename={self.filename}, "
+            f"shape={self.shape}, "
+            f"backend={type(self.backend).__name__}"
+            ")"
+        )
 
     def __len__(self) -> int:
         """Return the length of the video as the number of frames."""

--- a/sleap/io/video.py
+++ b/sleap/io/video.py
@@ -1565,7 +1565,4 @@ def load_video(
     if dataset is not None:
         kwargs["dataset"] = dataset
     kwargs["input_format"] = "channels_first" if channels_first else "channels_last"
-    return Video.from_filename(
-        filename,
-        **kwargs
-    )
+    return Video.from_filename(filename, **kwargs)

--- a/sleap/nn/config/data.py
+++ b/sleap/nn/config/data.py
@@ -26,6 +26,15 @@ class LabelsConfig:
             can be computed from these data during model optimization. This is also
             useful to explicitly keep track of the test set that should be used when
             multiple splits are created for training.
+        split_by_inds: If `True`, splits used for training will be determined by the
+            lists below by indexing into the labels in `training_labels`. If this is
+            `False`, the indices below will not be used even if specified. This is
+            useful for specifying the fixed split sets from examples within a single
+            labels file. If splits are generated automatically (using
+            `validation_fraction`), the selected indices are stored below for reference.
+        training_inds: List of indices of the training split labels.
+        validation_inds: List of indices of the validation split labels.
+        test_inds: List of indices of the test split labels.
         search_path_hints: List of paths to use for searching for missing data. This is
             useful when labels and data are moved across computers, network storage, or
             operating systems that may have different absolute paths than those stored
@@ -40,6 +49,10 @@ class LabelsConfig:
     validation_labels: Optional[Text] = None
     validation_fraction: float = 0.1
     test_labels: Optional[Text] = None
+    split_by_inds: bool = False
+    training_inds: Optional[List[int]] = None
+    validation_inds: Optional[List[int]] = None
+    test_inds: Optional[List[int]] = None
     search_path_hints: List[Text] = attr.ib(factory=list)
     skeletons: List[sleap.Skeleton] = attr.ib(factory=list)
 
@@ -76,13 +89,14 @@ class PreprocessingConfig:
             max stride (typically 32). This padding will be ignored when instance
             cropping inputs since the crop size should already be divisible by the
             model's max stride.
-        resize_and_pad_to_target: If True, will resize and pad all images in the dataset to match target dimensions.
-            This is useful when preprocessing datasets with mixed image dimensions (from different video resolutions).
-            Aspect ratio is preserved, and padding applied (if needed) to bottom or right of image only.
-        target_height: Target image height for 'resize_and_pad_to_target'. When not explicitly provided, inferred as the
-            max image height from the dataset.
-        target_width: Target image width for 'resize_and_pad_to_target'. When not explicitly provided, inferred as the
-            max image width from the dataset.
+        resize_and_pad_to_target: If True, will resize and pad all images in the dataset
+            to match target dimensions. This is useful when preprocessing datasets with
+            mixed image dimensions (from different video resolutions). Aspect ratio is
+            preserved, and padding applied (if needed) to bottom or right of image only.
+        target_height: Target image height for 'resize_and_pad_to_target'. When not
+            explicitly provided, inferred as the max image height from the dataset.
+        target_width: Target image width for 'resize_and_pad_to_target'. When not
+            explicitly provided, inferred as the max image width from the dataset.
     """
 
     ensure_rgb: bool = False

--- a/sleap/nn/config/outputs.py
+++ b/sleap/nn/config/outputs.py
@@ -151,6 +151,11 @@ class OutputsConfig:
         save_visualizations: If True, will render and save visualizations of the model
             predictions as PNGs to "{run_folder}/viz/{split}.{epoch:04d}.png", where the
             split is one of "train", "validation", "test".
+        delete_viz_images: If True, delete the saved visualizations after training
+            completes. This is useful to reduce the model folder size if you do not need
+            to keep the visualization images.
+        zip_outputs: If True, compress the run folder to a zip file. This will be named
+            "{run_folder}.zip".
         log_to_csv: If True, loss and metrics will be saved to a simple CSV after each
             epoch to "{run_folder}/training_log.csv"
         checkpointing: Configuration options related to model checkpointing.
@@ -165,6 +170,8 @@ class OutputsConfig:
     runs_folder: Text = "models"
     tags: List[Text] = attr.ib(factory=list)
     save_visualizations: bool = True
+    delete_viz_images: bool = True
+    zip_outputs: bool = False
     log_to_csv: bool = True
     checkpointing: CheckpointingConfig = attr.ib(factory=CheckpointingConfig)
     tensorboard: TensorBoardConfig = attr.ib(factory=TensorBoardConfig)

--- a/sleap/nn/config/training_job.py
+++ b/sleap/nn/config/training_job.py
@@ -118,7 +118,7 @@ class TrainingJobConfig:
         # Open and read the JSON data.
         with open(filename, "r") as f:
             json_data = f.read()
-        
+
         obj = cls.from_json(json_data)
         obj.filename = filename
         return obj

--- a/sleap/nn/config/training_job.py
+++ b/sleap/nn/config/training_job.py
@@ -27,13 +27,14 @@ parameters are aggregated and documented for end users (as opposed to developers
 import os
 import attr
 import cattr
+import sleap
 from sleap.nn.config.data import DataConfig
 from sleap.nn.config.model import ModelConfig
 from sleap.nn.config.optimization import OptimizationConfig
 from sleap.nn.config.outputs import OutputsConfig
 import json
 from jsmin import jsmin
-from typing import Text, Dict, Any
+from typing import Text, Dict, Any, Optional
 
 
 @attr.s(auto_attribs=True)
@@ -45,13 +46,18 @@ class TrainingJobConfig:
         model: Configuration options related to the model architecture.
         optimization: Configuration options related to the training.
         outputs: Configuration options related to outputs during training.
+        name: Optional name for this configuration profile.
+        description: Optional description of the configuration.
+        sleap_version: Version of SLEAP that generated this configuration.
     """
 
     data: DataConfig = attr.ib(factory=DataConfig)
     model: ModelConfig = attr.ib(factory=ModelConfig)
     optimization: OptimizationConfig = attr.ib(factory=OptimizationConfig)
     outputs: OutputsConfig = attr.ib(factory=OutputsConfig)
-    # TODO: store fixed config format version + SLEAP version?
+    name: Optional[Text] = ""
+    description: Optional[Text] = ""
+    sleap_version: Optional[Text] = sleap.__version__
 
     @classmethod
     def from_json_dicts(cls, json_data_dicts: Dict[Text, Any]) -> "TrainingJobConfig":

--- a/sleap/nn/config/training_job.py
+++ b/sleap/nn/config/training_job.py
@@ -49,6 +49,7 @@ class TrainingJobConfig:
         name: Optional name for this configuration profile.
         description: Optional description of the configuration.
         sleap_version: Version of SLEAP that generated this configuration.
+        filename: Path to this config file if it was loaded from disk.
     """
 
     data: DataConfig = attr.ib(factory=DataConfig)
@@ -58,6 +59,7 @@ class TrainingJobConfig:
     name: Optional[Text] = ""
     description: Optional[Text] = ""
     sleap_version: Optional[Text] = sleap.__version__
+    filename: Optional[Text] = ""
 
     @classmethod
     def from_json_dicts(cls, json_data_dicts: Dict[Text, Any]) -> "TrainingJobConfig":
@@ -88,16 +90,27 @@ class TrainingJobConfig:
         return cls.from_json_dicts(json_data_dicts)
 
     @classmethod
-    def load_json(cls, filename: Text) -> "TrainingJobConfig":
+    def load_json(
+        cls, filename: Text, load_training_config: bool = True
+    ) -> "TrainingJobConfig":
         """Load a training job configuration from a file.
 
         Arguments:
             filename: Path to a training job configuration JSON file or a directory
                 containing `"training_job.json"`.
+            load_training_config: If `True` (the default), prefer `training_job.json`
+                over `initial_config.json` if it is present in the same folder.
 
         Returns:
           A TrainingJobConfig instance parsed from the file.
         """
+        if load_training_config and filename.endswith("initial_config.json"):
+            training_config_path = os.path.join(
+                os.path.dirname(filename), "training_config.json"
+            )
+            if os.path.exists(training_config_path):
+                filename = training_config_path
+
         # Use stored configuration if a directory was provided.
         if os.path.isdir(filename):
             filename = os.path.join(filename, "training_config.json")
@@ -105,8 +118,10 @@ class TrainingJobConfig:
         # Open and read the JSON data.
         with open(filename, "r") as f:
             json_data = f.read()
-
-        return cls.from_json(json_data)
+        
+        obj = cls.from_json(json_data)
+        obj.filename = filename
+        return obj
 
     def to_json(self) -> str:
         """Serialize the configuration into JSON-encoded string format.
@@ -123,17 +138,22 @@ class TrainingJobConfig:
         Arguments:
             filename: Path to save the training job file to.
         """
+        self.filename = filename
         with open(filename, "w") as f:
             f.write(self.to_json())
 
 
-def load_config(filename: Text) -> TrainingJobConfig:
+def load_config(filename: Text, load_training_config: bool = True) -> TrainingJobConfig:
     """Load a training job configuration for a model run.
 
     Args:
         filename: Path to a JSON file or directory containing `training_job.json`.
+        load_training_config: If `True` (the default), prefer `training_job.json` over
+            `initial_config.json` if it is present in the same folder.
 
     Returns:
         The parsed `TrainingJobConfig`.
     """
-    return TrainingJobConfig.load_json(filename)
+    return TrainingJobConfig.load_json(
+        filename, load_training_config=load_training_config
+    )

--- a/sleap/nn/data/pipelines.py
+++ b/sleap/nn/data/pipelines.py
@@ -392,7 +392,7 @@ class SingleInstanceConfmapsPipeline:
 
         if self.optimization_config.augmentation_config.random_flip:
             pipeline += RandomFlipper.from_skeleton(
-                self.data_config.skeletons[0],
+                self.data_config.labels.skeletons[0],
                 horizontal=self.optimization_config.augmentation_config.flip_horizontal,
             )
         pipeline += ImgaugAugmenter.from_config(
@@ -541,7 +541,11 @@ class CentroidConfmapsPipeline:
             pipeline += Shuffler(
                 shuffle=True, buffer_size=self.optimization_config.shuffle_buffer_size
             )
-
+        if self.optimization_config.augmentation_config.random_flip:
+            pipeline += RandomFlipper.from_skeleton(
+                self.data_config.labels.skeletons[0],
+                horizontal=self.optimization_config.augmentation_config.flip_horizontal,
+            )
         pipeline += ImgaugAugmenter.from_config(
             self.optimization_config.augmentation_config
         )
@@ -702,7 +706,7 @@ class TopdownConfmapsPipeline:
             )
         if self.optimization_config.augmentation_config.random_flip:
             pipeline += RandomFlipper.from_skeleton(
-                self.data_config.skeletons[0],
+                self.data_config.labels.skeletons[0],
                 horizontal=self.optimization_config.augmentation_config.flip_horizontal,
             )
         pipeline += ImgaugAugmenter.from_config(
@@ -848,7 +852,7 @@ class BottomUpPipeline:
         aug_config = self.optimization_config.augmentation_config
         if aug_config.random_flip:
             pipeline += RandomFlipper.from_skeleton(
-                self.data_config.skeletons[0],
+                self.data_config.labels.skeletons[0],
                 horizontal=aug_config.flip_horizontal,
             )
         pipeline += ImgaugAugmenter.from_config(aug_config)

--- a/sleap/nn/data/providers.py
+++ b/sleap/nn/data/providers.py
@@ -170,7 +170,6 @@ class LabelsReader:
         first_image = tf.convert_to_tensor(self.labels[0].image)
         image_dtype = first_image.dtype
         image_num_channels = first_image.shape[-1]
-        n_nodes = len(self.labels.skeletons[0].nodes)
 
         def py_fetch_lf(ind):
             """Local function that will not be autographed."""
@@ -188,6 +187,7 @@ class LabelsReader:
                 insts = lf.instances
             insts = [inst for inst in insts if len(inst) > 0]
             n_instances = len(insts)
+            n_nodes = len(insts[0].skeleton) if n_instances > 0 else 0
 
             instances = np.full((n_instances, n_nodes, 2), np.nan, dtype="float32")
             for i, instance in enumerate(insts):

--- a/sleap/nn/data/providers.py
+++ b/sleap/nn/data/providers.py
@@ -186,6 +186,7 @@ class LabelsReader:
                 insts = lf.user_instances
             else:
                 insts = lf.instances
+            insts = [inst for inst in insts if len(inst) > 0]
             n_instances = len(insts)
 
             instances = np.full((n_instances, n_nodes, 2), np.nan, dtype="float32")

--- a/sleap/nn/data/training.py
+++ b/sleap/nn/data/training.py
@@ -24,7 +24,7 @@ def split_labels_train_val(
 
         `labels_train` and `labels_val` are `sleap.Label` objects containing the
         selected frames for each split. Their `videos`, `tracks` and `provenance`
-        attributes are identical to `labels` even if the split does not contain 
+        attributes are identical to `labels` even if the split does not contain
         instances with a particular video or track.
 
         `idx_train` and `idx_val` are list indices of the labeled frames within the

--- a/sleap/nn/data/training.py
+++ b/sleap/nn/data/training.py
@@ -12,7 +12,7 @@ from sklearn.model_selection import train_test_split
 
 def split_labels_train_val(
     labels: sleap.Labels, validation_fraction: float
-) -> Tuple[sleap.Labels, sleap.Labels]:
+) -> Tuple[sleap.Labels, List[int], sleap.Labels, List[int]]:
     """Make a train/validation split from a labels dataset.
 
     Args:
@@ -20,7 +20,17 @@ def split_labels_train_val(
         validation_fraction: Fraction of frames to use for validation.
 
     Returns:
-        A tuple of `(labels_train, labels_val)`.
+        A tuple of `(labels_train, idx_train, labels_val, idx_val)`.
+
+        `labels_train` and `labels_val` are `sleap.Label` objects containing the
+        selected frames for each split. Their `videos`, `tracks` and `provenance`
+        attributes are identical to `labels` even if the split does not contain 
+        instances with a particular video or track.
+
+        `idx_train` and `idx_val` are list indices of the labeled frames within the
+        input labels that were assigned to each split, i.e.:
+
+            `labels[idx_train] == labels_train[:]`
 
         If there is only one labeled frame in `labels`, both of the labels will contain
         the same frame.
@@ -48,7 +58,7 @@ def split_labels_train_val(
     labels_val.tracks = labels.tracks
     labels_val.provenance = labels.provenance
 
-    return labels_train, labels_val
+    return labels_train, idx_train, labels_val, idx_val
 
 
 def split_labels(

--- a/sleap/nn/data/training.py
+++ b/sleap/nn/data/training.py
@@ -39,7 +39,7 @@ def split_labels_train_val(
         it will be rounded to ensure there is at least one label in each.
     """
     if len(labels) == 1:
-        return labels, labels
+        return labels, [0], labels, [0]
 
     # Split indices.
     n_val = round(len(labels) * validation_fraction)

--- a/sleap/nn/evals.py
+++ b/sleap/nn/evals.py
@@ -37,8 +37,8 @@ from sleap.nn.config import (
 from sleap.nn.model import Model
 from sleap.nn.data.pipelines import LabelsReader
 from sleap.nn.inference import (
-    TopdownPredictor,
-    BottomupPredictor,
+    TopDownPredictor,
+    BottomUpPredictor,
     SingleInstancePredictor,
 )
 
@@ -671,21 +671,21 @@ def evaluate_model(
     # Setup predictor for evaluation.
     head_config = cfg.model.heads.which_oneof()
     if isinstance(head_config, CentroidsHeadConfig):
-        predictor = TopdownPredictor(
+        predictor = TopDownPredictor(
             centroid_config=cfg,
             centroid_model=model,
             confmap_config=None,
             confmap_model=None,
         )
     elif isinstance(head_config, CenteredInstanceConfmapsHeadConfig):
-        predictor = TopdownPredictor(
+        predictor = TopDownPredictor(
             centroid_config=None,
             centroid_model=None,
             confmap_config=cfg,
             confmap_model=model,
         )
     elif isinstance(head_config, MultiInstanceConfig):
-        predictor = sleap.nn.inference.BottomupPredictor(
+        predictor = sleap.nn.inference.BottomUpPredictor(
             bottomup_config=cfg, bottomup_model=model
         )
     elif isinstance(head_config, SingleInstanceConfmapsHeadConfig):

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -2900,11 +2900,11 @@ def load_model(
             tmp_dirs.append(tmp_dir)
 
             # Remove the temp dir when program exits in case something goes wrong.
-            atexit.register(shutil.rmtree, tmp_dir.name, True)
+            atexit.register(shutil.rmtree, tmp_dir.name, ignore_errors=True)
 
             # Extract and replace in the list.
             shutil.unpack_archive(model_path, extract_dir=tmp_dir.name)
-            models_paths[i] = tmp_dir.name
+            model_paths[i] = tmp_dir.name
 
     predictor = make_predictor_from_paths(
         model_paths, batch_size=batch_size, integral_refinement=refinement == "integral"

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -22,31 +22,32 @@ function which provides a simplified interface for creating `Predictor`s.
 """
 
 import attr
+import argparse
 import logging
 import warnings
 import os
 import tempfile
+import platform
 import shutil
 import atexit
 import rich.progress
 from collections import deque
 import json
 from time import time
+from datetime import datetime
 from pathlib import Path
 
 from abc import ABC, abstractmethod
-from typing import Text, Optional, List, Dict, Union, Iterator
+from typing import Text, Optional, List, Dict, Union, Iterator, Tuple
 
 import tensorflow as tf
 import numpy as np
 
 import sleap
-from sleap import util
 from sleap.nn.config import TrainingJobConfig
 from sleap.nn.model import Model
-from sleap.nn.tracking import Tracker, run_tracker
+from sleap.nn.tracking import Tracker
 from sleap.nn.paf_grouping import PAFScorer
-from sleap.nn.data.grouping import group_examples_iter
 from sleap.nn.data.pipelines import (
     Provider,
     Pipeline,
@@ -55,62 +56,22 @@ from sleap.nn.data.pipelines import (
     Normalizer,
     Resizer,
     Prefetcher,
-    LambdaFilter,
     KerasModelPredictor,
-    LocalPeakFinder,
-    PredictedInstanceCropper,
-    InstanceCentroidFinder,
-    InstanceCropper,
-    GlobalPeakFinder,
-    MockGlobalPeakFinder,
-    KeyFilter,
-    KeyRenamer,
-    KeyDeviceMover,
-    PredictedCenterInstanceNormalizer,
-    PointsRescaler,
 )
 
 logger = logging.getLogger(__name__)
 
 
-def safely_generate(ds: tf.data.Dataset, progress: bool = True):
-    """Yields examples from dataset, catching and logging exceptions."""
-    # Unsafe generating:
-    # for example in ds:
-    #     yield example
+def get_keras_model_path(path: Text) -> str:
+    """Utility method for finding the path to a saved Keras model.
 
-    ds_iter = iter(ds)
+    Args:
+        path: Path to a model run folder or job file.
 
-    i = 0
-    wall_t0 = time()
-    done = False
-    while not done:
-        try:
-            next_val = next(ds_iter)
-            yield next_val
-        except StopIteration:
-            done = True
-        except Exception as e:
-            logger.info(f"ERROR in sample index {i}")
-            logger.info(e)
-            logger.info("")
-        finally:
-            if not done:
-                i += 1
-
-            # Show the current progress (frames, time, fps)
-            if progress:
-                if (i and i % 1000 == 0) or done:
-                    elapsed_time = time() - wall_t0
-                    logger.info(
-                        f"Finished {i} examples in {elapsed_time:.2f} seconds "
-                        "(inference + postprocessing)"
-                    )
-                    if elapsed_time:
-                        logger.info(f"examples/s = {i/elapsed_time}")
-
-
-def get_keras_model_path(path: Text) -> Text:
+    Returns:
+        Path to `best_model.h5` in the run folder.
+    """
+    # TODO: Move this to TrainingJobConfig or Model?
     if path.endswith(".json"):
         path = os.path.dirname(path)
     return os.path.join(path, "best_model.h5")
@@ -137,11 +98,93 @@ class Predictor(ABC):
         kw_only=True,
     )
     report_rate: float = attr.ib(default=2.0, kw_only=True)
+    model_paths: List[str] = attr.ib(factory=list, kw_only=True)
 
     @property
     def report_period(self) -> float:
         """Time between progress reports in seconds."""
         return 1.0 / self.report_rate
+
+    @classmethod
+    def from_model_paths(
+        cls,
+        model_paths: Union[str, List[str]],
+        peak_threshold: float = 0.2,
+        integral_refinement: bool = True,
+        integral_patch_size: int = 5,
+        batch_size: int = 4,
+    ) -> "Predictor":
+        """Create the appropriate `Predictor` subclass from a list of model paths.
+
+        Args:
+            model_paths: A single or list of trained model paths.
+            peak_threshold: Minimum confidence map value to consider a peak as valid.
+            integral_refinement: If `True`, peaks will be refined with integral
+                regression. If `False`, `"local"`, peaks will be refined with quarter
+                pixel local gradient offset. This has no effect if the model has an
+                offset regression head.
+            integral_patch_size: Size of patches to crop around each rough peak for
+                integral refinement as an integer scalar.
+            batch_size: The default batch size to use when loading data for inference.
+                Higher values increase inference speed at the cost of higher memory
+                usage.
+
+        Returns:
+            A subclass of `Predictor`.
+
+        See also: `SingleInstancePredictor`, `TopDownPredictor`, `BottomUpPredictor`
+        """
+        # Read configs and find model types.
+        if isinstance(model_paths, str):
+            model_paths = [model_paths]
+        model_configs = [sleap.load_config(model_path) for model_path in model_paths]
+        model_paths = [cfg.filename for cfg in model_configs]
+        model_types = [
+            cfg.model.heads.which_oneof_attrib_name() for cfg in model_configs
+        ]
+
+        if "single_instance" in model_types:
+            predictor = SingleInstancePredictor.from_trained_models(
+                model_path=model_paths[model_types.index("single_instance")],
+                peak_threshold=peak_threshold,
+                integral_refinement=integral_refinement,
+                integral_patch_size=integral_patch_size,
+                batch_size=batch_size,
+            )
+
+        elif "centroid" in model_types or "centered_instance" in model_types:
+            centroid_model_path = None
+            if "centroid" in model_types:
+                centroid_model_path = model_paths[model_types.index("centroid")]
+
+            confmap_model_path = None
+            if "centered_instance" in model_types:
+                confmap_model_path = model_paths[model_types.index("centered_instance")]
+
+            predictor = TopDownPredictor.from_trained_models(
+                centroid_model_path=centroid_model_path,
+                confmap_model_path=confmap_model_path,
+                batch_size=batch_size,
+                peak_threshold=peak_threshold,
+                integral_refinement=integral_refinement,
+                integral_patch_size=integral_patch_size,
+            )
+
+        elif "multi_instance" in model_types:
+            predictor = BottomUpPredictor.from_trained_models(
+                model_path=model_paths[model_types.index("multi_instance")],
+                peak_threshold=peak_threshold,
+                integral_refinement=integral_refinement,
+                integral_patch_size=integral_patch_size,
+                batch_size=batch_size,
+            )
+
+        else:
+            raise ValueError(
+                "Could not create predictor from model paths:" + "\n".join(model_paths)
+            )
+        predictor.model_paths = model_paths
+        return predictor
 
     @classmethod
     @abstractmethod
@@ -244,6 +287,9 @@ class Predictor(ABC):
                     if elapsed_since_last_report > self.report_period:
                         progress.refresh()
 
+                    # Return results.
+                    yield ex
+
         elif self.verbosity == "json":
             n_processed = 0
             n_total = len(data_provider)
@@ -285,6 +331,9 @@ class Predictor(ABC):
                         flush=True,
                     )
                     last_report = time()
+
+                # Return results.
+                yield ex
         else:
             for ex in self.pipeline.make_dataset():
                 yield process_batch(ex)
@@ -327,59 +376,7 @@ class Predictor(ABC):
             return list(generator)
 
 
-@attr.s(auto_attribs=True)
-class MockPredictor(Predictor):
-    labels: sleap.Labels
-
-    @classmethod
-    def from_trained_models(cls, labels_path: Text):
-        labels = sleap.Labels.load_file(labels_path)
-        return cls(labels=labels)
-
-    def make_pipeline(self):
-        pass
-
-    def predict(self, data_provider: Provider):
-
-        prediction_video = None
-
-        # Try to match specified video by its full path
-        prediction_video_path = os.path.abspath(data_provider.video.filename)
-        for video in self.labels.videos:
-            if os.path.abspath(video.filename) == prediction_video_path:
-                prediction_video = video
-                break
-
-        if prediction_video is None:
-            # Try to match on filename (without path)
-            prediction_video_path = os.path.basename(data_provider.video.filename)
-            for video in self.labels.videos:
-                if os.path.basename(video.filename) == prediction_video_path:
-                    prediction_video = video
-                    break
-
-        if prediction_video is None:
-            # Default to first video in labels file
-            prediction_video = self.labels.videos[0]
-
-        # Get specified frames from labels file (or use None for all frames)
-        frame_idx_list = (
-            list(data_provider.example_indices)
-            if data_provider.example_indices
-            else None
-        )
-
-        frames = self.labels.find(video=prediction_video, frame_idx=frame_idx_list)
-
-        # Run tracker as specified
-        if self.tracker:
-            frames = run_tracker(tracker=self.tracker, frames=frames)
-            self.tracker.final_pass(frames)
-
-        # Return frames (there are no "raw" predictions we could return)
-        return frames
-
-
+# TODO: Rewrite this class.
 @attr.s(auto_attribs=True)
 class VisualPredictor(Predictor):
     """Predictor class for generating the visual output of model."""
@@ -449,6 +446,42 @@ class VisualPredictor(Predictor):
 
         self.pipeline = pipeline
 
+    def safely_generate(self, ds: tf.data.Dataset, progress: bool = True):
+        """Yields examples from dataset, catching and logging exceptions."""
+        # Unsafe generating:
+        # for example in ds:
+        #     yield example
+
+        ds_iter = iter(ds)
+
+        i = 0
+        wall_t0 = time()
+        done = False
+        while not done:
+            try:
+                next_val = next(ds_iter)
+                yield next_val
+            except StopIteration:
+                done = True
+            except Exception as e:
+                logger.info(f"ERROR in sample index {i}")
+                logger.info(e)
+                logger.info("")
+            finally:
+                if not done:
+                    i += 1
+
+                # Show the current progress (frames, time, fps)
+                if progress:
+                    if (i and i % 1000 == 0) or done:
+                        elapsed_time = time() - wall_t0
+                        logger.info(
+                            f"Finished {i} examples in {elapsed_time:.2f} seconds "
+                            "(inference + postprocessing)"
+                        )
+                        if elapsed_time:
+                            logger.info(f"examples/s = {i/elapsed_time}")
+
     def predict_generator(self, data_provider: Provider):
         if self.pipeline is None:
             # Pass in data provider when mocking one of the models.
@@ -457,7 +490,7 @@ class VisualPredictor(Predictor):
         self.pipeline.providers = [data_provider]
 
         # Yield each example from dataset, catching and logging exceptions
-        return safely_generate(self.pipeline.make_dataset())
+        return self.safely_generate(self.pipeline.make_dataset())
 
     def predict(self, data_provider: Provider):
         generator = self.predict_generator(data_provider)
@@ -2478,295 +2511,10 @@ class BottomUpPredictor(Predictor):
         return predicted_frames
 
 
-CLI_PREDICTORS = {
-    "topdown": TopDownPredictor,
-    "bottomup": BottomUpPredictor,
-    "single": SingleInstancePredictor,
-}
-
-
-def make_cli_parser():
-    import argparse
-    from sleap.util import frame_list
-
-    parser = argparse.ArgumentParser()
-
-    # Add args for entire pipeline
-    parser.add_argument(
-        "video_path", type=str, nargs="?", default="", help="Path to video file"
-    )
-    parser.add_argument(
-        "-m",
-        "--model",
-        dest="models",
-        action="append",
-        help="Path to trained model directory (with training_config.json). "
-        "Multiple models can be specified, each preceded by --model.",
-    )
-
-    parser.add_argument(
-        "--frames",
-        type=frame_list,
-        default="",
-        help="List of frames to predict. Either comma separated list (e.g. 1,2,3) or "
-        "a range separated by hyphen (e.g. 1-3, for 1,2,3). (default is entire video)",
-    )
-    parser.add_argument(
-        "--only-labeled-frames",
-        action="store_true",
-        default=False,
-        help="Only run inference on labeled frames (when running on labels dataset file).",
-    )
-    parser.add_argument(
-        "--only-suggested-frames",
-        action="store_true",
-        default=False,
-        help="Only run inference on suggested frames (when running on labels dataset file).",
-    )
-    parser.add_argument(
-        "-o",
-        "--output",
-        type=str,
-        default=None,
-        help="The output filename to use for the predicted data.",
-    )
-    parser.add_argument(
-        "--labels",
-        type=str,
-        default=None,
-        help="Path to labels dataset file (for inference on multiple videos or for re-tracking pre-existing predictions).",
-    )
-
-    parser.add_argument(
-        "--verbosity",
-        type=str,
-        choices=["none", "rich", "json"],
-        default="rich",
-        help=(
-            "Verbosity of inference progress reporting. 'none' does not output "
-            "anything during inference, 'rich' displays an updating progress bar, "
-            "and 'json' outputs the progress as a JSON encoded response to the "
-            "console."
-        ),
-    )
-
-    # TODO: better video parameters
-
-    parser.add_argument(
-        "--video.dataset", type=str, default="", help="The dataset for HDF5 videos."
-    )
-
-    parser.add_argument(
-        "--video.input_format",
-        type=str,
-        default="",
-        help="The input_format for HDF5 videos.",
-    )
-
-    device_group = parser.add_mutually_exclusive_group(required=False)
-    device_group.add_argument(
-        "--cpu",
-        action="store_true",
-        help="Run inference only on CPU. If not specified, will use available GPU.",
-    )
-    device_group.add_argument(
-        "--first-gpu",
-        action="store_true",
-        help="Run inference on the first GPU, if available.",
-    )
-    device_group.add_argument(
-        "--last-gpu",
-        action="store_true",
-        help="Run inference on the last GPU, if available.",
-    )
-    device_group.add_argument(
-        "--gpu", type=int, default=0, help="Run inference on the i-th GPU specified."
-    )
-
-    # Add args for each predictor class
-    for predictor_name, predictor_class in CLI_PREDICTORS.items():
-        if "peak_threshold" in attr.fields_dict(predictor_class):
-            # get the default value to show in help string, although we'll
-            # use None as default so that unspecified vals won't be passed to
-            # builder.
-            default_val = attr.fields_dict(predictor_class)["peak_threshold"].default
-
-            parser.add_argument(
-                f"--{predictor_name}.peak_threshold",
-                type=float,
-                default=None,
-                help=f"Threshold to use when finding peaks in {predictor_class.__name__} (default: {default_val}).",
-            )
-
-        if "batch_size" in attr.fields_dict(predictor_class):
-            default_val = attr.fields_dict(predictor_class)["batch_size"].default
-            parser.add_argument(
-                f"--{predictor_name}.batch_size",
-                type=int,
-                default=4,
-                help=f"Batch size to use for model inference in {predictor_class.__name__} (default: {default_val}).",
-            )
-
-    # Add args for tracking
-    Tracker.add_cli_parser_args(parser, arg_scope="tracking")
-
-    return parser
-
-
-def make_video_readers_from_cli(args) -> List[VideoReader]:
-    if args.video_path:
-        # TODO: better support for video params
-        video_kwargs = dict(
-            dataset=vars(args).get("video.dataset"),
-            input_format=vars(args).get("video.input_format"),
-        )
-
-        video_reader = VideoReader.from_filepath(
-            filename=args.video_path, example_indices=args.frames, **video_kwargs
-        )
-
-        return [video_reader]
-
-    if args.labels:
-        # TODO: Replace with LabelsReader.
-        labels = sleap.Labels.load_file(args.labels)
-
-        readers = []
-
-        if args.only_labeled_frames:
-            user_labeled_frames = labels.user_labeled_frames
-        else:
-            user_labeled_frames = []
-
-        for video in labels.videos:
-            if args.only_labeled_frames:
-                frame_indices = [
-                    lf.frame_idx for lf in user_labeled_frames if lf.video == video
-                ]
-                readers.append(VideoReader(video=video, example_indices=frame_indices))
-            elif args.only_suggested_frames:
-                readers.append(
-                    VideoReader(
-                        video=video,
-                        example_indices=labels.get_video_suggestions(
-                            video, user_labeled=False
-                        ),
-                    )
-                )
-            else:
-                readers.append(VideoReader(video=video))
-
-        return readers
-
-    raise ValueError("You must specify either video_path or labels dataset path.")
-
-
-def make_predictor_from_paths(paths, **kwargs) -> Predictor:
-    """Build predictor object from a list of model paths."""
-    return make_predictor_from_models(find_heads_for_model_paths(paths), **kwargs)
-
-
-def find_heads_for_model_paths(paths) -> Dict[str, str]:
-    """Given list of models paths, returns dict with path keyed by head name."""
-    trained_model_paths = dict()
-
-    if paths is None:
-        return trained_model_paths
-
-    for model_path in paths:
-        # Load the model config
-        cfg = TrainingJobConfig.load_json(model_path)
-
-        # Get the head from the model (i.e., what the model will predict)
-        key = cfg.model.heads.which_oneof_attrib_name()
-
-        # If path is to config file json, then get the path to parent dir
-        if model_path.endswith(".json"):
-            model_path = os.path.dirname(model_path)
-
-        trained_model_paths[key] = model_path
-
-    return trained_model_paths
-
-
-def make_predictor_from_models(
-    trained_model_paths: Dict[str, str],
-    labels_path: Optional[str] = None,
-    policy_args: Optional[dict] = None,
-    **kwargs,
-) -> Predictor:
-    """Given dict of paths keyed by head name, returns appropriate predictor."""
-
-    def get_relevant_args(key):
-        if policy_args is not None and key in policy_args:
-            return policy_args[key]
-        return dict()
-
-    if "multi_instance" in trained_model_paths:
-        predictor = BottomUpPredictor.from_trained_models(
-            trained_model_paths["multi_instance"],
-            **get_relevant_args("bottomup"),
-            **kwargs,
-        )
-    elif "single_instance" in trained_model_paths:
-        predictor = SingleInstancePredictor.from_trained_models(
-            trained_model_paths["single_instance"],
-            **get_relevant_args("single"),
-            **kwargs,
-        )
-    elif (
-        "centroid" in trained_model_paths and "centered_instance" in trained_model_paths
-    ):
-        predictor = TopDownPredictor.from_trained_models(
-            centroid_model_path=trained_model_paths["centroid"],
-            confmap_model_path=trained_model_paths["centered_instance"],
-            **get_relevant_args("topdown"),
-            **kwargs,
-        )
-    elif len(trained_model_paths) == 0 and labels_path:
-        predictor = MockPredictor.from_trained_models(labels_path=labels_path)
-    else:
-        raise ValueError(
-            f"Unable to run inference with {list(trained_model_paths.keys())} heads."
-        )
-
-    return predictor
-
-
-def make_tracker_from_cli(policy_args):
-    if "tracking" in policy_args:
-        tracker = Tracker.make_tracker_by_name(**policy_args["tracking"])
-        return tracker
-
-    return None
-
-
-def save_predictions_from_cli(args, predicted_frames, prediction_metadata=None):
-    from sleap import Labels
-
-    if args.output:
-        output_path = args.output
-    elif args.video_path:
-        out_dir = os.path.dirname(args.video_path)
-        out_name = os.path.basename(args.video_path) + ".predictions.slp"
-        output_path = os.path.join(out_dir, out_name)
-    elif args.labels:
-        out_dir = os.path.dirname(args.labels)
-        out_name = os.path.basename(args.labels) + ".predictions.slp"
-        output_path = os.path.join(out_dir, out_name)
-    else:
-        # We shouldn't ever get here but if we do, just save in working dir.
-        output_path = "predictions.slp"
-
-    labels = Labels(labeled_frames=predicted_frames, provenance=prediction_metadata)
-
-    print(f"Saving: {output_path}")
-    Labels.save_file(labels, output_path)
-
-
 def load_model(
     model_path: Union[str, List[str]],
     batch_size: int = 4,
+    peak_threshold: float = 0.2,
     refinement: str = "integral",
     tracker: Optional[str] = None,
     tracker_window: int = 5,
@@ -2782,6 +2530,7 @@ def load_model(
             `best_model.h5`.
         batch_size: Number of frames to predict at a time. Larger values result in
             faster inference speeds, but require more memory.
+        peak_threshold: Minimum confidence map value to consider a peak as valid.
         refinement: If `"integral"`, peak locations will be refined with integral
             regression. If `"local"`, peaks will be refined with quarter pixel local
             gradient offset. This has no effect if the model has an offset regression
@@ -2845,8 +2594,11 @@ def load_model(
     if disable_gpu_preallocation:
         sleap.disable_preallocation()
 
-    predictor = make_predictor_from_paths(
-        model_paths, batch_size=batch_size, integral_refinement=refinement == "integral"
+    predictor = Predictor.from_model_paths(
+        model_paths,
+        peak_threshold=peak_threshold,
+        integral_refinement=refinement == "integral",
+        batch_size=batch_size,
     )
     predictor.verbosity = progress_reporting
     if tracker is not None:
@@ -2864,12 +2616,314 @@ def load_model(
     return predictor
 
 
-def main():
-    """CLI for running inference."""
-    parser = make_cli_parser()
-    args, _ = parser.parse_known_args()
-    print(args)
+def _make_cli_parser() -> argparse.ArgumentParser:
+    """Create argument parser for CLI.
 
+    Returns:
+        The `argparse.ArgumentParser` that defines the CLI options.
+    """
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "data_path",
+        type=str,
+        nargs="?",
+        default="",
+        help=(
+            "Path to data to predict on. This can be a labels (.slp) file or any "
+            "supported video format."
+        ),
+    )
+    parser.add_argument(
+        "-m",
+        "--model",
+        dest="models",
+        action="append",
+        help=(
+            "Path to trained model directory (with training_config.json). "
+            "Multiple models can be specified, each preceded by --model."
+        ),
+    )
+    parser.add_argument(
+        "--frames",
+        type=sleap.util.frame_list,
+        default="",
+        help=(
+            "List of frames to predict when running on a video. Can be specified as a "
+            "comma separated list (e.g. 1,2,3) or a range separated by hyphen (e.g., "
+            "1-3, for 1,2,3). If not provided, defaults to predicting on the entire "
+            "video."
+        ),
+    )
+    parser.add_argument(
+        "--only-labeled-frames",
+        action="store_true",
+        default=False,
+        help=(
+            "Only run inference on user labeled frames when running on labels dataset. "
+            "This is useful for generating predictions to compare against ground truth."
+        ),
+    )
+    parser.add_argument(
+        "--only-suggested-frames",
+        action="store_true",
+        default=False,
+        help=(
+            "Only run inference on unlabeled suggested frames when running on labels "
+            "dataset. This is useful for generating predictions for initialization "
+            "during labeling."
+        ),
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        default=None,
+        help=(
+            "The output filename to use for the predicted data. If not provided, "
+            "defaults to '[data_path].predictions.slp'."
+        ),
+    )
+    parser.add_argument(
+        "--no-empty-frames",
+        action="store_true",
+        default=False,
+        help=(
+            "Clear any empty frames that did not have any detected instances before "
+            "saving to output."
+        ),
+    )
+    parser.add_argument(
+        "--verbosity",
+        type=str,
+        choices=["none", "rich", "json"],
+        default="rich",
+        help=(
+            "Verbosity of inference progress reporting. 'none' does not output "
+            "anything during inference, 'rich' displays an updating progress bar, "
+            "and 'json' outputs the progress as a JSON encoded response to the "
+            "console."
+        ),
+    )
+    parser.add_argument(
+        "--video.dataset", type=str, default=None, help="The dataset for HDF5 videos."
+    )
+    parser.add_argument(
+        "--video.input_format",
+        type=str,
+        default="channels_last",
+        help="The input_format for HDF5 videos.",
+    )
+    device_group = parser.add_mutually_exclusive_group(required=False)
+    device_group.add_argument(
+        "--cpu",
+        action="store_true",
+        help="Run inference only on CPU. If not specified, will use available GPU.",
+    )
+    device_group.add_argument(
+        "--first-gpu",
+        action="store_true",
+        help="Run inference on the first GPU, if available.",
+    )
+    device_group.add_argument(
+        "--last-gpu",
+        action="store_true",
+        help="Run inference on the last GPU, if available.",
+    )
+    device_group.add_argument(
+        "--gpu", type=int, default=0, help="Run inference on the i-th GPU specified."
+    )
+
+    parser.add_argument(
+        "--peak_threshold",
+        type=float,
+        default=0.2,
+        help="Minimum confidence map value to consider a peak as valid.",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=4,
+        help=(
+            "Number of frames to predict at a time. Larger values result in faster "
+            "inference speeds, but require more memory."
+        ),
+    )
+
+    # Deprecated legacy args. These will still be parsed for backward compatibility but
+    # are hidden from the CLI help.
+    parser.add_argument(
+        "--labels",
+        type=str,
+        default=argparse.SUPPRESS,
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--single.peak_threshold",
+        type=float,
+        default=argparse.SUPPRESS,
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--topdown.peak_threshold",
+        type=float,
+        default=argparse.SUPPRESS,
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--bottomup.peak_threshold",
+        type=float,
+        default=argparse.SUPPRESS,
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--single.batch_size",
+        type=float,
+        default=argparse.SUPPRESS,
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--topdown.batch_size",
+        type=float,
+        default=argparse.SUPPRESS,
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--bottomup.batch_size",
+        type=float,
+        default=argparse.SUPPRESS,
+        help=argparse.SUPPRESS,
+    )
+
+    # Add tracker args.
+    Tracker.add_cli_parser_args(parser, arg_scope="tracking")
+
+    return parser
+
+
+def _make_provider_from_cli(args: argparse.Namespace) -> Tuple[Provider, str]:
+    """Make data provider from parsed CLI args.
+
+    Args:
+        args: Parsed CLI namespace.
+
+    Returns:
+        A tuple of `(provider, data_path)` with the data `Provider` and path to the data
+        that was specified in the args.
+    """
+    # Figure out which input path to use.
+    labels_path = getattr(args, "labels", None)
+    if labels_path is not None:
+        data_path = labels_path
+    else:
+        data_path = args.data_path
+
+    if data_path is None:
+        raise ValueError("You must specify a path to a video or a labels dataset.")
+
+    if data_path.endswith(".slp"):
+        labels = sleap.Labels.load_file(data_path)
+
+        if args.only_labeled_frames:
+            provider = LabelsReader.from_user_labeled_frames(labels)
+        elif args.only_suggested_frames:
+            provider = LabelsReader.from_unlabeled_suggestions(labels)
+        else:
+            provider = LabelsReader(labels)
+
+    else:
+        # TODO: Clean this up.
+        video_kwargs = dict(
+            dataset=vars(args).get("video.dataset"),
+            input_format=vars(args).get("video.input_format"),
+        )
+        provider = VideoReader.from_filepath(
+            filename=data_path, example_indices=args.frames, **video_kwargs
+        )
+
+    return provider, data_path
+
+
+def _make_predictor_from_cli(args: argparse.Namespace) -> Predictor:
+    """Make predictor from parsed CLI args.
+
+    Args:
+        args: Parsed CLI namespace.
+
+    Returns:
+        The `Predictor` created from loaded models.
+    """
+    peak_threshold = None
+    for deprecated_arg in [
+        "single.peak_threshold",
+        "topdown.peak_threshold",
+        "bottomup.peak_threshold",
+    ]:
+        val = getattr(args, deprecated_arg, None)
+        if val is not None:
+            peak_threshold = val
+    if peak_threshold is None:
+        peak_threshold = args.peak_threshold
+
+    batch_size = None
+    for deprecated_arg in [
+        "single.batch_size",
+        "topdown.batch_size",
+        "bottomup.batch_size",
+    ]:
+        val = getattr(args, deprecated_arg, None)
+        if val is not None:
+            batch_size = val
+    if batch_size is None:
+        batch_size = args.batch_size
+
+    predictor = Predictor.from_model_paths(
+        args.models,
+        peak_threshold=peak_threshold,
+        integral_refinement=True,
+        batch_size=batch_size,
+    )
+    predictor.verbosity = args.verbosity
+    return predictor
+
+
+def _make_tracker_from_cli(args: argparse.Namespace) -> Optional[Tracker]:
+    """Make tracker from parsed CLI arguments.
+
+    Args:
+        args: Parsed CLI namespace.
+
+    Returns:
+        An instance of `Tracker` or `None` if tracking method was not specified.
+    """
+    policy_args = sleap.util.make_scoped_dictionary(vars(args), exclude_nones=True)
+    if "tracking" in policy_args:
+        tracker = Tracker.make_tracker_by_name(**policy_args["tracking"])
+        return tracker
+    return None
+
+
+def main():
+    """Entrypoint for `sleap-track` CLI for running inference."""
+    t0 = time()
+    start_timestamp = str(datetime.now())
+    print("Started inference at:", start_timestamp)
+
+    # Setup CLI.
+    parser = _make_cli_parser()
+
+    # Parse inputs.
+    args, _ = parser.parse_known_args()
+
+    args_msg = ["Args:"]
+    for name, val in vars(args).items():
+        if name == "frames" and val is not None:
+            args_msg.append(f"  frames: {min(val)}-{max(val)} ({len(val)})")
+        else:
+            args_msg.append(f"  {name}: {val}")
+    print("\n".join(args_msg))
+
+    # Setup devices.
     if args.cpu or not sleap.nn.system.is_gpu_system():
         sleap.nn.system.use_cpu_only()
     else:
@@ -2889,44 +2943,47 @@ def main():
     sleap.nn.system.summary()
     print()
 
-    video_readers = make_video_readers_from_cli(args)
+    # Setup data loader.
+    provider, data_path = _make_provider_from_cli(args)
 
-    # Find the specified models
-    model_paths_by_head = find_heads_for_model_paths(args.models)
+    # Setup models.
+    predictor = _make_predictor_from_cli(args)
 
-    # Make a scoped dictionary with args specified from cli
-    policy_args = util.make_scoped_dictionary(vars(args), exclude_nones=True)
-
-    # Create appropriate predictor given these models
-    predictor = make_predictor_from_models(
-        model_paths_by_head, labels_path=args.labels, policy_args=policy_args
-    )
-    predictor.verbosity = args.verbosity
-
-    # Make the tracker
-    tracker = make_tracker_from_cli(policy_args)
+    # Setup tracker.
+    tracker = _make_tracker_from_cli(args)
     predictor.tracker = tracker
 
     # Run inference!
-    t0 = time()
-    predicted_frames = []
+    labels_pr = predictor.predict(provider)
 
-    for video_reader in video_readers:
-        video_predicted_frames = predictor.predict(video_reader).labeled_frames
-        predicted_frames.extend(video_predicted_frames)
+    if args.no_empty_frames:
+        # Clear empty frames if specified.
+        labels_pr.remove_empty_frames()
 
-    # Create dictionary of metadata we want to save with predictions
-    prediction_metadata = dict()
-    for head, path in model_paths_by_head.items():
-        prediction_metadata[f"model.{head}.path"] = os.path.abspath(path)
-    for scope in policy_args.keys():
-        for key, val in policy_args[scope].items():
-            prediction_metadata[f"{scope}.{key}"] = val
-    prediction_metadata["video.path"] = args.video_path
-    prediction_metadata["sleap.version"] = sleap.__version__
+    finish_timestamp = str(datetime.now())
+    total_elapsed = time() - t0
+    print("Finished inference at:", finish_timestamp)
+    print(f"Total runtime: {total_elapsed} secs")
+    print(f"Predicted frames: {len(labels_pr)}/{len(provider)}")
 
-    save_predictions_from_cli(args, predicted_frames, prediction_metadata)
-    print(f"Total Time: {time() - t0}")
+    output_path = args.output
+    if output_path is None:
+        output_path = data_path + ".predictions.slp"
+
+    # Add provenance metadata to predictions.
+    labels_pr.provenance["sleap_version"] = sleap.__version__
+    labels_pr.provenance["platform"] = platform.platform()
+    labels_pr.provenance["data_path"] = data_path
+    labels_pr.provenance["model_paths"] = predictor.model_paths
+    labels_pr.provenance["output_path"] = output_path
+    labels_pr.provenance["predictor"] = type(predictor).__name__
+    labels_pr.provenance["total_elapsed"] = total_elapsed
+    labels_pr.provenance["start_timestamp"] = start_timestamp
+    labels_pr.provenance["finish_timestamp"] = finish_timestamp
+
+    # Save results.
+    labels_pr.save(output_path)
+    print("Saved output:", output_path)
 
 
 if __name__ == "__main__":

--- a/sleap/nn/monitor.py
+++ b/sleap/nn/monitor.py
@@ -28,6 +28,8 @@ class LossViewer(QtWidgets.QMainWindow):
 
         self.show_controller = show_controller
         self.stop_button = None
+        self.cancel_button = None
+        self.canceled = False
 
         self.redraw_batch_interval = 40
         self.batches_to_show = -1  # -1 to show all
@@ -162,9 +164,12 @@ class LossViewer(QtWidgets.QMainWindow):
 
             control_layout.addStretch(1)
 
-            self.stop_button = QtWidgets.QPushButton("Stop Training")
+            self.stop_button = QtWidgets.QPushButton("Stop Early")
             self.stop_button.clicked.connect(self.stop)
             control_layout.addWidget(self.stop_button)
+            self.cancel_button = QtWidgets.QPushButton("Cancel Training")
+            self.cancel_button.clicked.connect(self.cancel)
+            control_layout.addWidget(self.cancel_button)
 
             widget = QtWidgets.QWidget()
             widget.setLayout(control_layout)
@@ -242,12 +247,19 @@ class LossViewer(QtWidgets.QMainWindow):
         self.timer.timeout.connect(self.check_messages)
         self.timer.start(20)
 
+    def cancel(self):
+        """Set the cancel flag."""
+        self.canceled = True
+        if self.cancel_button is not None:
+            self.cancel_button.setText("Canceling...")
+            self.cancel_button.setEnabled(False)
+
     def stop(self):
         """Action to stop training."""
 
         if self.zmq_ctrl is not None:
             # send command to stop training
-            logger.info("Sending command to stop training")
+            logger.info("Sending command to stop training.")
             self.zmq_ctrl.send_string(jsonpickle.encode(dict(command="stop")))
 
         # Disable the button

--- a/sleap/nn/training.py
+++ b/sleap/nn/training.py
@@ -1369,35 +1369,63 @@ def main():
     parser.add_argument(
         "training_job_path", help="Path to training job profile JSON file."
     )
-    parser.add_argument("labels_path", help="Path to labels file to use for training.")
+    parser.add_argument(
+        "labels_path",
+        nargs="?",
+        default="",
+        help=(
+            "Path to labels file to use for training. If specified, overrides the path "
+            "specified in the training job config."
+        ),
+    )
     parser.add_argument(
         "--video-paths",
         type=str,
         default="",
-        help="List of paths for finding videos in case paths inside labels file need fixing.",
+        help=(
+            "List of paths for finding videos in case paths inside labels file are "
+            "not accessible."
+        ),
     )
     parser.add_argument(
         "--val_labels",
         "--val",
-        help="Path to labels file to use for validation (overrides training job path if set).",
+        help=(
+            "Path to labels file to use for validation. If specified, overrides the "
+            "path specified in the training job config."
+        ),
     )
     parser.add_argument(
         "--test_labels",
         "--test",
-        help="Path to labels file to use for test (overrides training job path if set).",
+        help=(
+            "Path to labels file to use for test. If specified, overrides the path "
+            "specified in the training job config."
+        ),
     )
     parser.add_argument(
         "--tensorboard",
         action="store_true",
-        help="Enables TensorBoard logging to the run path.",
+        help=(
+            "Enable TensorBoard logging to the run path if not already specified in "
+            "the training job config."
+        ),
     )
     parser.add_argument(
         "--save_viz",
         action="store_true",
-        help="Enables saving of prediction visualizations to the run folder.",
+        help=(
+            "Enable saving of prediction visualizations to the run folder if not "
+            "already specified in the training job config."
+        ),
     )
     parser.add_argument(
-        "--zmq", action="store_true", help="Enables ZMQ logging (for GUI)."
+        "--zmq",
+        action="store_true",
+        help=(
+            "Enable ZMQ logging (for GUI) if not already specified in the training "
+            "job config."
+        ),
     )
     parser.add_argument(
         "--run_name",
@@ -1424,9 +1452,9 @@ def main():
 
     # Override config settings for CLI-based training.
     job_config.outputs.save_outputs = True
-    job_config.outputs.tensorboard.write_logs = args.tensorboard
-    job_config.outputs.zmq.publish_updates = args.zmq
-    job_config.outputs.zmq.subscribe_to_controller = args.zmq
+    job_config.outputs.tensorboard.write_logs |= args.tensorboard
+    job_config.outputs.zmq.publish_updates |= args.zmq
+    job_config.outputs.zmq.subscribe_to_controller |= args.zmq
     if args.run_name != "":
         job_config.outputs.run_name = args.run_name
     if args.prefix != "":
@@ -1434,6 +1462,8 @@ def main():
     if args.suffix != "":
         job_config.outputs.run_name_suffix = args.suffix
     job_config.outputs.save_visualizations |= args.save_viz
+    if args.labels_path == "":
+        args.labels_path = None
 
     logger.info("Versions:")
     sleap.versions()

--- a/sleap/nn/training.py
+++ b/sleap/nn/training.py
@@ -44,7 +44,7 @@ from sleap.nn.data.pipelines import (
     BottomUpPipeline,
     KeyMapper,
 )
-from sleap.nn.data.training import split_labels
+from sleap.nn.data.training import split_labels_train_val
 
 # Optimization
 from sleap.nn.config import OptimizationConfig
@@ -157,7 +157,7 @@ class DataReaders:
                 validation, video_search=video_search_paths
             )
         elif isinstance(validation, float):
-            training, validation = split_labels(training, [-1, validation])
+            training, validation = split_labels_train_val(training, validation)
 
         if isinstance(test, str):
             test = sleap.Labels.load_file(test, video_search=video_search_paths)

--- a/sleap/nn/training.py
+++ b/sleap/nn/training.py
@@ -725,9 +725,14 @@ class Trainer(ABC):
     def _setup_outputs(self):
         """Set up output-related functionality."""
         if self.config.outputs.save_outputs:
-            # Build path to run folder.
+            # Build path to run folder. Timestamp will be added automatically.
+            # Example: 210204_041707.centroid.n=300
+            model_type = self.config.model.heads.which_oneof_attrib_name()
+            n = len(self.data_readers.training_labels) + len(
+                self.data_readers.validation_labels
+            )
             self.run_path = setup_new_run_folder(
-                self.config.outputs, base_run_name=type(self.model.backbone).__name__
+                self.config.outputs, base_run_name=f"{model_type}.n={n}"
             )
 
         # Setup output callbacks.

--- a/sleap/nn/training.py
+++ b/sleap/nn/training.py
@@ -5,6 +5,7 @@ import re
 from datetime import datetime
 from time import time
 import logging
+import shutil
 
 import tensorflow as tf
 import numpy as np
@@ -643,6 +644,9 @@ class Trainer(ABC):
         logger.info("  Heads: ")
         for i, head in enumerate(self.model.heads):
             logger.info(f"  heads[{i}] = {head}")
+        logger.info("  Outputs: ")
+        for i, output in enumerate(self.model.keras_model.outputs):
+            logger.info(f"  outputs[{i}] = {output}")
 
     @property
     def keras_model(self) -> tf.keras.Model:
@@ -841,6 +845,20 @@ class Trainer(ABC):
                     model=self.model,
                     save=True,
                     split_name="test",
+                )
+
+            if (
+                self.config.outputs.save_visualizations
+                and self.config.outputs.delete_viz_images
+            ):
+                viz_path = os.path.join(self.run_path, "viz")
+                logger.info(f"Deleting visualization directory: {viz_path}")
+                shutil.rmtree(viz_path)
+
+            if self.config.outputs.zip_outputs:
+                logger.info(f"Packaging results to: {self.run_path}.zip")
+                shutil.make_archive(
+                    base_name=self.run_path, root_dir=self.run_path, format="zip"
                 )
 
 

--- a/sleap/nn/training.py
+++ b/sleap/nn/training.py
@@ -1416,6 +1416,9 @@ def main():
         job_config.outputs.run_name_suffix = args.suffix
     job_config.outputs.save_visualizations |= args.save_viz
 
+    logger.info("Versions:")
+    sleap.versions()
+
     logger.info(f"Training labels file: {args.labels_path}")
     logger.info(f"Training profile: {job_filename}")
     logger.info("")

--- a/sleap/nn/training.py
+++ b/sleap/nn/training.py
@@ -262,7 +262,7 @@ def setup_optimizer(config: OptimizationConfig) -> tf.keras.optimizers.Optimizer
 
 
 def setup_losses(
-    config: OptimizationConfig
+    config: OptimizationConfig,
 ) -> Callable[[tf.Tensor, tf.Tensor], tf.Tensor]:
     """Set up model loss function from config."""
     losses = [tf.keras.losses.MeanSquaredError()]

--- a/sleap/nn/training.py
+++ b/sleap/nn/training.py
@@ -207,9 +207,9 @@ class DataReaders:
                 validation_inds,
             ) = split_labels_train_val(training.with_user_labels_only(), validation)
             logger.info(
-                    f"  Splits: Training = {len(training_inds)} /"
-                    f" Validation = {len(validation_inds)}."
-                )
+                f"  Splits: Training = {len(training_inds)} /"
+                f" Validation = {len(validation_inds)}."
+            )
             if update_config and labels_config is not None:
                 labels_config.training_inds = training_inds
                 labels_config.validation_inds = validation_inds
@@ -740,14 +740,18 @@ class Trainer(ABC):
             )
             + key_mapper
         )
-        logger.info(f"Training set: n = {len(self.data_readers.training_labels_reader)}")
+        logger.info(
+            f"Training set: n = {len(self.data_readers.training_labels_reader)}"
+        )
         self.validation_pipeline = (
             self.pipeline_builder.make_training_pipeline(
                 self.data_readers.validation_labels_reader
             )
             + key_mapper
         )
-        logger.info(f"Validation set: n = {len(self.data_readers.validation_labels_reader)}")
+        logger.info(
+            f"Validation set: n = {len(self.data_readers.validation_labels_reader)}"
+        )
 
     def _setup_optimization(self):
         """Set up optimizer, loss functions and compile the model."""

--- a/sleap/nn/training.py
+++ b/sleap/nn/training.py
@@ -555,6 +555,9 @@ class Trainer(ABC):
         # Copy input config before we make any changes.
         initial_config = copy.deepcopy(config)
 
+        # Store SLEAP version on the training process.
+        config.sleap_version = sleap.__version__
+
         # Create data readers and store loaded skeleton.
         data_readers = DataReaders.from_config(
             config.data.labels,

--- a/sleap/prefs.py
+++ b/sleap/prefs.py
@@ -12,7 +12,7 @@ class Preferences(object):
 
     _prefs = None
     _defaults = {
-        "medium step size": 4,
+        "medium step size": 10,
         "large step size": 100,
         "color predicted": False,
         "palette": "standard",
@@ -47,6 +47,11 @@ class Preferences(object):
     def save(self):
         """Save preferences to file."""
         util.save_config_yaml(self._filename, self._prefs)
+
+    def reset_to_default(self):
+        """Reset preferences to default."""
+        util.save_config_yaml(self._filename, self._defaults)
+        self.load()
 
     def _validate_key(self, key):
         if key not in self._defaults:

--- a/sleap/prefs.py
+++ b/sleap/prefs.py
@@ -21,7 +21,7 @@ class Preferences(object):
         "trail width": 4.0,
         "trail node count": 1,
         "marker size": 4,
-        "window state": b""
+        "window state": b"",
     }
     _filename = "preferences.yaml"
 

--- a/sleap/prefs.py
+++ b/sleap/prefs.py
@@ -15,12 +15,14 @@ class Preferences(object):
         "medium step size": 10,
         "large step size": 100,
         "color predicted": False,
+        "propagate track labels": True,
         "palette": "standard",
         "bold lines": False,
         "trail length": 0,
         "trail width": 4.0,
         "trail node count": 1,
         "marker size": 4,
+        "edge style": "Line",
         "window state": b"",
     }
     _filename = "preferences.yaml"

--- a/sleap/prefs.py
+++ b/sleap/prefs.py
@@ -20,6 +20,7 @@ class Preferences(object):
         "trail length": 0,
         "trail width": 4.0,
         "trail node count": 1,
+        "marker size": 4,
         "window state": b""
     }
     _filename = "preferences.yaml"

--- a/sleap/prefs.py
+++ b/sleap/prefs.py
@@ -20,10 +20,7 @@ class Preferences(object):
         "trail length": 0,
         "trail width": 4.0,
         "trail node count": 1,
-        "hide videos dock": False,
-        "hide skeleton dock": False,
-        "hide instances dock": False,
-        "hide labeling suggestions dock": False,
+        "window state": b""
     }
     _filename = "preferences.yaml"
 

--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -29,7 +29,8 @@ H5FileRef = Union[str, h5py.File]
 
 
 class EdgeType(Enum):
-    """
+    """Type of edge in the skeleton graph.
+
     The skeleton graph can store different types of edges to represent
     different things. All edges must specify one or more of the
     following types:
@@ -46,9 +47,13 @@ class EdgeType(Enum):
 
 @attr.s(auto_attribs=True, slots=True, eq=False, order=False)
 class Node:
-    """
-    The class :class:`Node` represents a potential skeleton node.
-    (But note that nodes can exist without being part of a skeleton.)
+    """This class represents node in the skeleton graph, i.e., a body part.
+
+    Note: Nodes can exist without being part of a skeleton.
+
+    Attributes:
+        name: String name of the node.
+        weight: Weight of the node (not currently used).
     """
 
     name: str
@@ -94,8 +99,7 @@ class Skeleton:
     _skeleton_idx = count(0)
 
     def __init__(self, name: str = None):
-        """
-        Initialize an empty skeleton object.
+        """Initialize an empty skeleton object.
 
         Skeleton objects, once created, can be modified by adding nodes
         and edges.
@@ -103,7 +107,6 @@ class Skeleton:
         Args:
             name: A name for this skeleton.
         """
-
         # If no skeleton was create, try to create a unique name for this Skeleton.
         if name is None or not isinstance(name, str) or not name:
             name = "Skeleton-" + str(next(self._skeleton_idx))
@@ -138,15 +141,13 @@ class Skeleton:
         )
 
     def matches(self, other: "Skeleton") -> bool:
-        """
-        Compare this `Skeleton` to another, ignoring skeleton name and
-        the identities of the `Node` objects in each graph.
+        """Compare this `Skeleton` to another, ignoring name and node identities.
 
         Args:
             other: The other skeleton.
 
         Returns:
-            True if match, False otherwise.
+            `True` if the skeleton graphs are isomorphic and node names.
         """
 
         def dict_match(dict1, dict2):
@@ -160,17 +161,16 @@ class Skeleton:
         if not is_isomorphic:
             return False
 
-        # Now check that the nodes have the same labels and order. They can have
-        # different weights I guess?!
+        # Now check that the nodes have the same labels and order.
         for node1, node2 in zip(self._graph.nodes, other._graph.nodes):
             if node1.name != node2.name:
                 return False
 
-        # Check if the two graphs are equal
         return True
 
     @property
     def is_arborescence(self) -> bool:
+        """Return whether this skeleton graph forms an arborescence."""
         return nx.algorithms.tree.recognition.is_arborescence(self._graph)
 
     @property
@@ -187,7 +187,7 @@ class Skeleton:
 
     @property
     def graph(self):
-        """Returns subgraph of BODY edges for skeleton."""
+        """Return subgraph of BODY edges for skeleton."""
         edges = [
             (src, dst, key)
             for src, dst, key, edge_type in self._graph.edges(keys=True, data="type")
@@ -200,7 +200,7 @@ class Skeleton:
 
     @property
     def graph_symmetry(self):
-        """Returns subgraph of symmetric edges for skeleton."""
+        """Return subgraph of symmetric edges for skeleton."""
         edges = [
             (src, dst, key)
             for src, dst, key, edge_type in self._graph.edges(keys=True, data="type")
@@ -210,8 +210,7 @@ class Skeleton:
 
     @staticmethod
     def find_unique_nodes(skeletons: List["Skeleton"]) -> List[Node]:
-        """
-        Find all unique nodes from a list of skeletons.
+        """Find all unique nodes from a list of skeletons.
 
         Args:
             skeletons: The list of skeletons.
@@ -223,8 +222,7 @@ class Skeleton:
 
     @staticmethod
     def make_cattr(idx_to_node: Dict[int, Node] = None) -> cattr.Converter:
-        """
-        Make cattr.Convert() for `Skeleton`.
+        """Make cattr.Convert() for `Skeleton`.
 
         Make a cattr.Converter() that registers structure/unstructure
         hooks for Skeleton objects to handle serialization of skeletons.
@@ -262,7 +260,8 @@ class Skeleton:
 
     @name.setter
     def name(self, name: str):
-        """
+        """Set skeleton name (no-op).
+
         A skeleton object cannot change its name.
 
         This property is immutable because it is used to hash skeletons.
@@ -287,8 +286,7 @@ class Skeleton:
 
     @classmethod
     def rename_skeleton(cls, skeleton: "Skeleton", name: str) -> "Skeleton":
-        """
-        Make copy of skeleton with new name.
+        """Make copy of skeleton with new name.
 
         This property is immutable because it is used to hash skeletons.
         If you want to rename a Skeleton you must use this class method.
@@ -374,7 +372,6 @@ class Skeleton:
             A list of (src_node_ind, dst_node_ind), where indices are subscripts into
             the Skeleton.nodes list.
         """
-
         return [
             (self.nodes.index(src_node), self.nodes.index(dst_node))
             for src_node, dst_node in self.edges
@@ -445,8 +442,7 @@ class Skeleton:
         )
 
     def node_to_index(self, node: NodeRef) -> int:
-        """
-        Return the index of the node, accepts either `Node` or name.
+        """Return the index of the node, accepts either `Node` or name.
 
         Args:
             node: The name of the node or the Node object.
@@ -463,8 +459,8 @@ class Skeleton:
         except ValueError:
             return node_list.index(self.find_node(node))
 
-    def edge_to_index(self, source: NodeRef, destination: NodeRef):
-        """Returns the index of edge from source to destination."""
+    def edge_to_index(self, source: NodeRef, destination: NodeRef) -> int:
+        """Return the index of edge from source to destination."""
         source = self.find_node(source)
         destination = self.find_node(destination)
         edge = (source, destination)
@@ -482,9 +478,6 @@ class Skeleton:
 
         Raises:
             ValueError: If name is not unique.
-
-        Returns:
-            None
         """
         if not isinstance(name, str):
             raise TypeError("Cannot add nodes to the skeleton that are not str")
@@ -495,14 +488,10 @@ class Skeleton:
         self._graph.add_node(Node(name))
 
     def add_nodes(self, name_list: List[str]):
-        """
-        Add a list of nodes representing animal parts to the skeleton.
+        """Add a list of nodes representing animal parts to the skeleton.
 
         Args:
             name_list: List of strings representing the nodes.
-
-        Returns:
-            None
         """
         for node in name_list:
             self.add_node(node)
@@ -650,8 +639,7 @@ class Skeleton:
         self._graph.remove_edge(source_node, destination_node)
 
     def clear_edges(self):
-        """Deletes all edges in skeleton."""
-
+        """Delete all edges in skeleton."""
         for src, dst in self.edges:
             self.delete_edge(src, dst)
 
@@ -675,8 +663,9 @@ class Skeleton:
         """
         node1_node, node2_node = self.find_node(node1), self.find_node(node2)
 
-        # We will represent symmetric pairs in the skeleton via additional edges in the _graph
-        # These edges will have a special attribute signifying they are not part of the skeleton itself
+        # We will represent symmetric pairs in the skeleton via additional edges in the
+        # _graph. These edges will have a special attribute signifying they are not part
+        # of the skeleton itself
 
         if node1 == node2:
             raise ValueError("Cannot add symmetry to the same node.")
@@ -695,8 +684,7 @@ class Skeleton:
         self._graph.add_edge(node2_node, node1_node, type=EdgeType.SYMMETRY)
 
     def delete_symmetry(self, node1: NodeRef, node2: NodeRef):
-        """
-        Deletes a previously established symmetry between two nodes.
+        """Delete a previously established symmetry between two nodes.
 
         Args:
             node1: One node (by `Node` object or name) in symmetric pair.
@@ -727,8 +715,7 @@ class Skeleton:
         self._graph.remove_edges_from(edges)
 
     def get_symmetry(self, node: NodeRef) -> Optional[Node]:
-        """
-        Returns the node symmetric with the specified node.
+        """Return the node symmetric with the specified node.
 
         Args:
             node: Node (by `Node` object or name) to query.
@@ -755,8 +742,7 @@ class Skeleton:
             raise ValueError(f"{node} has more than one symmetry.")
 
     def get_symmetry_name(self, node: NodeRef) -> Optional[str]:
-        """
-        Returns the name of the node symmetric with the specified node.
+        """Return the name of the node symmetric with the specified node.
 
         Args:
             node: Node (by `Node` object or name) to query.
@@ -768,8 +754,7 @@ class Skeleton:
         return None if symmetric_node is None else symmetric_node.name
 
     def __getitem__(self, node_name: str) -> dict:
-        """
-        Retrieves the node data associated with skeleton node.
+        """Retrieve the node data associated with skeleton node.
 
         Args:
             node_name: The name from which to retrieve data.
@@ -788,8 +773,7 @@ class Skeleton:
         return self._graph.nodes.data()[node]
 
     def __contains__(self, node_name: str) -> bool:
-        """
-        Checks if specified node exists in skeleton.
+        """Check if specified node exists in skeleton.
 
         Args:
             node_name: the node name to query
@@ -798,6 +782,10 @@ class Skeleton:
             True if node is in the skeleton.
         """
         return self.has_node(node_name)
+
+    def __len__(self) -> int:
+        """Return the number of nodes in the skeleton."""
+        return len(self.nodes)
 
     def relabel_node(self, old_name: str, new_name: str):
         """

--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -23,6 +23,7 @@ import networkx as nx
 from networkx.readwrite import json_graph
 from scipy.io import loadmat
 
+
 NodeRef = Union[str, "Node"]
 H5FileRef = Union[str, h5py.File]
 
@@ -117,12 +118,24 @@ class Skeleton:
         """Return full description of the skeleton."""
         return (
             f"Skeleton(name='{self.name}', "
-            f"nodes={self.node_names}, edges={self.edge_names})"
+            f"nodes={self.node_names}, "
+            f"edges={self.edge_names}, "
+            f"symmetries={self.symmetry_names}"
+            ")"
         )
 
     def __str__(self) -> str:
         """Return short readable description of the skeleton."""
-        return f"Skeleton(nodes={len(self.nodes)}, edges={len(self.edges)})"
+        nodes = ", ".join(self.node_names)
+        edges = ", ".join([f"{s}->{d}" for (s, d) in self.edge_names])
+        symm = ", ".join([f"{s}<->{d}" for (s, d) in self.symmetry_names])
+        return (
+            "Skeleton("
+            f"nodes=[{nodes}], "
+            f"edges=[{edges}], "
+            f"symmetries=[{symm}]"
+            ")"
+        )
 
     def matches(self, other: "Skeleton") -> bool:
         """
@@ -394,8 +407,15 @@ class Skeleton:
             if edge_type == EdgeType.SYMMETRY
         ]
         # Get rid of duplicates
-        symmetries = list(set([tuple(sorted(e, key=operator.attrgetter("name"))) for e in symmetries]))
+        symmetries = list(
+            set([tuple(sorted(e, key=operator.attrgetter("name"))) for e in symmetries])
+        )
         return symmetries
+
+    @property
+    def symmetry_names(self) -> List[Tuple[str, str]]:
+        """List of symmetry edges as tuples of node names."""
+        return [(s.name, d.name) for (s, d) in self.symmetries]
 
     @property
     def symmetries_full(self) -> List[Tuple[Node, Node, Any, Any]]:

--- a/sleap/util.py
+++ b/sleap/util.py
@@ -311,7 +311,7 @@ def get_config_yaml(shortname: str, get_defaults: bool = False) -> dict:
     config_path = get_config_file(shortname, get_defaults=get_defaults)
     with open(config_path, "r") as f:
         print(f"Loading config: {config_path}")
-        return yaml.load(f, Loader=yaml.SafeLoader)
+        return yaml.load(f, Loader=yaml.Loader)
 
 
 def save_config_yaml(shortname: str, data: Any) -> dict:

--- a/sleap/util.py
+++ b/sleap/util.py
@@ -380,16 +380,3 @@ def find_files_by_suffix(
             )
 
     return matching_files
-
-
-def open_file(filename):
-    """
-    Opens file (as if double-clicked by user).
-
-    https://stackoverflow.com/questions/17317219/is-there-an-platform-independent-equivalent-of-os-startfile/17317468#17317468
-    """
-    if sys.platform == "win32":
-        os.startfile(filename)
-    else:
-        opener = "open" if sys.platform == "darwin" else "xdg-open"
-        subprocess.call([opener, filename])

--- a/sleap/util.py
+++ b/sleap/util.py
@@ -310,12 +310,14 @@ def get_config_file(
 def get_config_yaml(shortname: str, get_defaults: bool = False) -> dict:
     config_path = get_config_file(shortname, get_defaults=get_defaults)
     with open(config_path, "r") as f:
+        print(f"Loading config: {config_path}")
         return yaml.load(f, Loader=yaml.SafeLoader)
 
 
 def save_config_yaml(shortname: str, data: Any) -> dict:
     yaml_path = get_config_file(shortname, ignore_file_not_found=True)
     with open(yaml_path, "w") as f:
+        print(f"Saving config: {yaml_path}")
         yaml.dump(data, f)
 
 

--- a/sleap/util.py
+++ b/sleap/util.py
@@ -310,7 +310,6 @@ def get_config_file(
 def get_config_yaml(shortname: str, get_defaults: bool = False) -> dict:
     config_path = get_config_file(shortname, get_defaults=get_defaults)
     with open(config_path, "r") as f:
-        print(f"Loading config: {config_path}")
         return yaml.load(f, Loader=yaml.Loader)
 
 

--- a/sleap/version.py
+++ b/sleap/version.py
@@ -20,6 +20,7 @@ def versions():
     import tensorflow as tf
     import numpy as np
     import platform
+
     vers = {}
     vers["SLEAP"] = __version__
     vers["TensorFlow"] = tf.__version__

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -54,6 +54,12 @@ def test_import_labels_from_dlc_folder():
 def test_get_new_version_filename():
     assert get_new_version_filename("labels.slp") == "labels copy.slp"
     assert get_new_version_filename("labels.v0.slp") == "labels.v1.slp"
-    assert get_new_version_filename("/a/b/labels.slp") == str(PurePath("/a/b/labels copy.slp"))
-    assert get_new_version_filename("/a/b/labels.v0.slp") == str(PurePath("/a/b/labels.v1.slp"))
-    assert get_new_version_filename("/a/b/labels.v01.slp") == str(PurePath("/a/b/labels.v02.slp"))
+    assert get_new_version_filename("/a/b/labels.slp") == str(
+        PurePath("/a/b/labels copy.slp")
+    )
+    assert get_new_version_filename("/a/b/labels.v0.slp") == str(
+        PurePath("/a/b/labels.v1.slp")
+    )
+    assert get_new_version_filename("/a/b/labels.v01.slp") == str(
+        PurePath("/a/b/labels.v02.slp")
+    )

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -1,5 +1,10 @@
-from sleap.gui.commands import CommandContext, ImportDeepLabCutFolder
+from sleap.gui.commands import (
+    CommandContext,
+    ImportDeepLabCutFolder,
+    get_new_version_filename,
+)
 from sleap.io.pathutils import fix_path_separator
+from pathlib import PurePath
 
 
 def test_delete_user_dialog(centered_pair_predictions):
@@ -44,3 +49,11 @@ def test_import_labels_from_dlc_folder():
     }
 
     assert set([l.frame_idx for l in labels.labeled_frames]) == {0, 0, 1}
+
+
+def test_get_new_version_filename():
+    assert get_new_version_filename("labels.slp") == "labels copy.slp"
+    assert get_new_version_filename("labels.v0.slp") == "labels.v1.slp"
+    assert get_new_version_filename("/a/b/labels.slp") == str(PurePath("/a/b/labels copy.slp"))
+    assert get_new_version_filename("/a/b/labels.v0.slp") == str(PurePath("/a/b/labels.v1.slp"))
+    assert get_new_version_filename("/a/b/labels.v01.slp") == str(PurePath("/a/b/labels.v02.slp"))

--- a/tests/io/test_video.py
+++ b/tests/io/test_video.py
@@ -10,7 +10,7 @@ from tests.fixtures.videos import (
     TEST_SMALL_ROBOT_MP4_FILE,
     TEST_H5_DSET,
     TEST_H5_INPUT_FORMAT,
-    TEST_SMALL_CENTERED_PAIR_VID
+    TEST_SMALL_CENTERED_PAIR_VID,
 )
 
 # FIXME:

--- a/tests/nn/data/test_data_training.py
+++ b/tests/nn/data/test_data_training.py
@@ -1,64 +1,75 @@
 import numpy as np
-import tensorflow as tf
-from sleap.nn.system import use_cpu_only
-
-use_cpu_only()  # hide GPUs for test
-
 import sleap
-from sleap.nn.data.providers import LabelsReader
-from sleap.nn.data import training
+from sleap.nn.data.training import split_labels_train_val
 
 
-def test_split_labels_reader(min_labels):
-    labels = sleap.Labels([min_labels[0], min_labels[0], min_labels[0], min_labels[0]])
-    labels_reader = LabelsReader(labels)
-    reader1, reader2 = training.split_labels_reader(labels_reader, [0.5, 0.5])
-    assert len(reader1) == 2
-    assert len(reader2) == 2
-    assert (
-        len(set(reader1.example_indices).intersection(set(reader2.example_indices)))
-        == 0
+sleap.use_cpu_only()  # hide GPUs for test
+
+
+def test_split_labels_train_val():
+    vid = sleap.Video(backend=sleap.io.video.MediaVideo)
+    labels = sleap.Labels([sleap.LabeledFrame(video=vid, frame_idx=0)])
+
+    train, val = split_labels_train_val(labels, 0)
+    assert len(train) == 1
+    assert len(val) == 1
+
+    train, val = split_labels_train_val(labels, 0.1)
+    assert len(train) == 1
+    assert len(val) == 1
+
+    train, val = split_labels_train_val(labels, 0.5)
+    assert len(train) == 1
+    assert len(val) == 1
+
+    train, val = split_labels_train_val(labels, 1.0)
+    assert len(train) == 1
+    assert len(val) == 1
+
+    labels = sleap.Labels(
+        [
+            sleap.LabeledFrame(video=vid, frame_idx=0),
+            sleap.LabeledFrame(video=vid, frame_idx=1),
+        ]
     )
+    train, val = split_labels_train_val(labels, 0)
+    assert len(train) == 1
+    assert len(val) == 1
+    assert train[0].frame_idx != val[0].frame_idx
 
-    reader1, reader2 = training.split_labels_reader(labels_reader, [0.1, 0.5])
-    assert len(reader1) == 1
-    assert len(reader2) == 2
-    assert (
-        len(set(reader1.example_indices).intersection(set(reader2.example_indices)))
-        == 0
+    train, val = split_labels_train_val(labels, 0.1)
+    assert len(train) == 1
+    assert len(val) == 1
+    assert train[0].frame_idx != val[0].frame_idx
+
+    train, val = split_labels_train_val(labels, 0.5)
+    assert len(train) == 1
+    assert len(val) == 1
+    assert train[0].frame_idx != val[0].frame_idx
+
+    train, val = split_labels_train_val(labels, 1.0)
+    assert len(train) == 1
+    assert len(val) == 1
+    assert train[0].frame_idx != val[0].frame_idx
+
+    labels = sleap.Labels(
+        [
+            sleap.LabeledFrame(video=vid, frame_idx=0),
+            sleap.LabeledFrame(video=vid, frame_idx=1),
+            sleap.LabeledFrame(video=vid, frame_idx=2),
+        ]
     )
+    train, val = split_labels_train_val(labels, 0)
+    assert len(train) == 2
+    assert len(val) == 1
 
-    reader1, reader2 = training.split_labels_reader(labels_reader, [0.1, -1])
-    assert len(reader1) == 1
-    assert len(reader2) == 3
-    assert (
-        len(set(reader1.example_indices).intersection(set(reader2.example_indices)))
-        == 0
-    )
+    train, val = split_labels_train_val(labels, 0.1)
+    assert len(train) == 2
+    assert len(val) == 1
 
-    labels = sleap.Labels([min_labels[0], min_labels[0], min_labels[0], min_labels[0]])
-    labels_reader = LabelsReader(labels, example_indices=[1, 2, 3])
-    reader1, reader2 = training.split_labels_reader(labels_reader, [0.1, -1])
-    assert len(reader1) == 1
-    assert len(reader2) == 2
-    assert (
-        len(set(reader1.example_indices).intersection(set(reader2.example_indices)))
-        == 0
-    )
-    assert 0 not in reader1.example_indices
-    assert 0 not in reader2.example_indices
+    train, val = split_labels_train_val(labels, 0.5)
+    assert len(train) + len(val) == 3
 
-
-def test_keymapper():
-    ds = tf.data.Dataset.from_tensors({"a": 0, "b": 1})
-    mapper = training.KeyMapper(key_maps={"a": "x", "b": "y"})
-    ds = mapper.transform_dataset(ds)
-    np.testing.assert_array_equal(next(iter(ds)), {"x": 0, "y": 1})
-    assert mapper.input_keys == ["a", "b"]
-    assert mapper.output_keys == ["x", "y"]
-
-    ds = tf.data.Dataset.from_tensors({"a": 0, "b": 1})
-    ds = training.KeyMapper(key_maps=[{"a": "x"}, {"b": "y"}]).transform_dataset(ds)
-    np.testing.assert_array_equal(next(iter(ds)), ({"x": 0}, {"y": 1}))
-    assert mapper.input_keys == ["a", "b"]
-    assert mapper.output_keys == ["x", "y"]
+    train, val = split_labels_train_val(labels, 1.0)
+    assert len(train) == 1
+    assert len(val) == 2

--- a/tests/nn/data/test_data_training.py
+++ b/tests/nn/data/test_data_training.py
@@ -10,19 +10,19 @@ def test_split_labels_train_val():
     vid = sleap.Video(backend=sleap.io.video.MediaVideo)
     labels = sleap.Labels([sleap.LabeledFrame(video=vid, frame_idx=0)])
 
-    train, val = split_labels_train_val(labels, 0)
+    train, train_inds, val, val_inds = split_labels_train_val(labels, 0)
     assert len(train) == 1
     assert len(val) == 1
 
-    train, val = split_labels_train_val(labels, 0.1)
+    train, train_inds, val, val_inds = split_labels_train_val(labels, 0.1)
     assert len(train) == 1
     assert len(val) == 1
 
-    train, val = split_labels_train_val(labels, 0.5)
+    train, train_inds, val, val_inds = split_labels_train_val(labels, 0.5)
     assert len(train) == 1
     assert len(val) == 1
 
-    train, val = split_labels_train_val(labels, 1.0)
+    train, train_inds, val, val_inds = split_labels_train_val(labels, 1.0)
     assert len(train) == 1
     assert len(val) == 1
 
@@ -32,22 +32,22 @@ def test_split_labels_train_val():
             sleap.LabeledFrame(video=vid, frame_idx=1),
         ]
     )
-    train, val = split_labels_train_val(labels, 0)
+    train, train_inds, val, val_inds = split_labels_train_val(labels, 0)
     assert len(train) == 1
     assert len(val) == 1
     assert train[0].frame_idx != val[0].frame_idx
 
-    train, val = split_labels_train_val(labels, 0.1)
+    train, train_inds, val, val_inds = split_labels_train_val(labels, 0.1)
     assert len(train) == 1
     assert len(val) == 1
     assert train[0].frame_idx != val[0].frame_idx
 
-    train, val = split_labels_train_val(labels, 0.5)
+    train, train_inds, val, val_inds = split_labels_train_val(labels, 0.5)
     assert len(train) == 1
     assert len(val) == 1
     assert train[0].frame_idx != val[0].frame_idx
 
-    train, val = split_labels_train_val(labels, 1.0)
+    train, train_inds, val, val_inds = split_labels_train_val(labels, 1.0)
     assert len(train) == 1
     assert len(val) == 1
     assert train[0].frame_idx != val[0].frame_idx
@@ -59,17 +59,17 @@ def test_split_labels_train_val():
             sleap.LabeledFrame(video=vid, frame_idx=2),
         ]
     )
-    train, val = split_labels_train_val(labels, 0)
+    train, train_inds, val, val_inds = split_labels_train_val(labels, 0)
     assert len(train) == 2
     assert len(val) == 1
 
-    train, val = split_labels_train_val(labels, 0.1)
+    train, train_inds, val, val_inds = split_labels_train_val(labels, 0.1)
     assert len(train) == 2
     assert len(val) == 1
 
-    train, val = split_labels_train_val(labels, 0.5)
+    train, train_inds, val, val_inds = split_labels_train_val(labels, 0.5)
     assert len(train) + len(val) == 3
 
-    train, val = split_labels_train_val(labels, 1.0)
+    train, train_inds, val, val_inds = split_labels_train_val(labels, 1.0)
     assert len(train) == 1
     assert len(val) == 2

--- a/tests/nn/test_inference.py
+++ b/tests/nn/test_inference.py
@@ -23,8 +23,8 @@ from sleap.nn.inference import (
     FindInstancePeaksGroundTruth,
     FindInstancePeaks,
     TopDownInferenceModel,
-    TopdownPredictor,
-    BottomupPredictor,
+    TopDownPredictor,
+    BottomUpPredictor,
     load_model,
 )
 
@@ -492,7 +492,7 @@ def test_single_instance_predictor(
 
 
 def test_topdown_predictor_centroid(min_labels, min_centroid_model_path):
-    predictor = TopdownPredictor.from_trained_models(
+    predictor = TopDownPredictor.from_trained_models(
         centroid_model_path=min_centroid_model_path
     )
     labels_pr = predictor.predict(min_labels)
@@ -512,7 +512,7 @@ def test_topdown_predictor_centroid(min_labels, min_centroid_model_path):
 def test_topdown_predictor_centered_instance(
     min_labels, min_centered_instance_model_path
 ):
-    predictor = TopdownPredictor.from_trained_models(
+    predictor = TopDownPredictor.from_trained_models(
         confmap_model_path=min_centered_instance_model_path
     )
     labels_pr = predictor.predict(min_labels)
@@ -530,7 +530,7 @@ def test_topdown_predictor_centered_instance(
 
 
 def test_topdown_predictor_bottomup(min_labels, min_bottomup_model_path):
-    predictor = BottomupPredictor.from_trained_models(
+    predictor = BottomUpPredictor.from_trained_models(
         model_path=min_bottomup_model_path
     )
     labels_pr = predictor.predict(min_labels)
@@ -557,7 +557,7 @@ def test_load_model(
     assert isinstance(predictor, SingleInstancePredictor)
 
     predictor = load_model([min_centroid_model_path, min_centered_instance_model_path])
-    assert isinstance(predictor, TopdownPredictor)
+    assert isinstance(predictor, TopDownPredictor)
 
     predictor = load_model(min_bottomup_model_path)
-    assert isinstance(predictor, BottomupPredictor)
+    assert isinstance(predictor, BottomUpPredictor)

--- a/tests/test_skeleton.py
+++ b/tests/test_skeleton.py
@@ -396,13 +396,3 @@ def test_arborescence():
     assert len(skeleton.cycles) == 0
     assert len(skeleton.root_nodes) == 1
     assert len(skeleton.in_degree_over_one) == 1
-
-
-def test_repr_str():
-    skel = Skeleton(name="skel")
-    skel.add_node("A")
-    skel.add_node("B")
-    skel.add_edge("A", "B")
-
-    assert repr(skel) == "Skeleton(name='skel', nodes=['A', 'B'], edges=[('A', 'B')])"
-    assert str(skel) == "Skeleton(nodes=2, edges=1)"


### PR DESCRIPTION
Laundry list of small features and tweaks:

## High level APIs:
- `sleap.load_video()`: create a `sleap.Video` from filename
- `sleap.load_config()`: load training job config json from model folders
- `sleap.load_file()` now takes a `match_to` kwarg to align data structure instances with other labels for easy comparison and manipulation.
- `sleap.versions()`: print package/OS versions
- `Labels`, `LabeledFrame`, `Instance`, `PredictedInstance`, `Video`, `Skeleton` now all have readable `__repr__` and `__str__`.
- `Labels.export()` to save to analysis HDF5
- `Labels.numpy()`, `LabeledFrame.numpy()` to convert main data structures to numpy
- `Labels.describe()` is more comprehensive overview of a dataset.
- `Labels.load_deeplabcut_folder()` to interactively import a maDLC dataset.

## Core workflow
- **Add ability to add any frame as suggestion and modify suggestion list.** This makes it possible to use the suggestions as a "labeling queue". This can be used to keep track of labeled frames and frames intended to be labeled (either detected algorithmically or manually selected frames of interest by user). This list also serves as a convenient target for inference for initialization/reprediction after training:
![image](https://user-images.githubusercontent.com/3187454/107023176-1d86f200-675b-11eb-981d-373caa298000.png)
- Add `Labels.clear_suggestions()`, `Labels.unlabeled_suggestions`, `Labels.get_unlabeled_suggestion_inds()`, `Labels.remove_empty_frames()`, `LabelsReader.from_user_labeled_frames()`, `LabelsReader.from_unlabeled_suggestions()` to support suggestion-driven workflow
- **Remote workflow:** Support for packaging output model folders as a zip file after training for easy download. Support for zip files as input to `sleap.load_model()`.
- **Remote workflow:** Support for packaging training + inference data, training job configurations, and CLI launch scripts into a single zip file for easy upload to Colab or other remote node:
![image](https://user-images.githubusercontent.com/3187454/107023020-eca6bd00-675a-11eb-9c7f-3a06a77ec7f9.png)
![image](https://user-images.githubusercontent.com/3187454/107026045-0cd87b00-675f-11eb-8e36-e112fce9b5f0.png)
- **File** -> **Save as...** now uses `labels.v000.slp` as  the default filename and scans the containing directory for labels following this pattern to increment the version number automatically. Saving the labels to a new version now takes just two keyboard strokes (Ctrl + Shift + S -> Enter by default). These two changes should direct users towards label versioning best practices.

## GUI/UX
- Window state (panels/tabs locations and visibility) are now persisted across sessions and restored when GUI is opened.
- Add option to adjust node marker size to make them easier to see on high resolution displays. This and other visualization settings are now appropriately persisted across sessions.
- Adjusted keyboard shortcuts to more sensible defaults and added ability to reset to "factory defaults".
- Added progress indicators for long running operations such as exporting training packages and running inference. Inference progress is also displayed in terminal and notebooks:
![image](https://user-images.githubusercontent.com/3187454/107022708-976aab80-675a-11eb-98fa-6c1c14ba2bdc.png) ![image](https://user-images.githubusercontent.com/3187454/107022598-773aec80-675a-11eb-8671-484907481ed2.png)
![image](https://user-images.githubusercontent.com/3187454/107022471-4a86d500-675a-11eb-87f3-acecd7db3597.png)
- Training and inference now have a **Cancel** button which immediately kills the subprocess and cleans up temp files or incomplete outputs.
- Training package exporting options are moved to a submenu with clearer descriptions of what they will save.
- Moved random flip augmentation options to a simpler dropdown menu (none, horizontal, vertical) rather than two checkboxes (enable/disable + horizontal/vertical)
- Add `name` and `description` fields to `TrainingJobConfig` to make it easier to annotate preset profiles with information relevant for users to select between them. This will be displayed in the GUI in a future update to drive a simplified training dialog workflow.

## Training/inference
- Training CLI now doesn't override true parameters in the config with flag false defaults (e.g., `config.outputs.save_visualizations` works when `--save_viz` is not passed).
- Training CLI no longer requires the positional `labels_path` arg since this can be specified in the config like the validation and test splits.
- Training will now delete the visualizations subfolders if `config.outputs.delete_viz_images` is true (the default). This was often larger than the models themselves and usually only used during GUI-based training for live visualization.
- Training will now zip the model folder if `self.config.outputs.zip_outputs` is true to support core remote workflow.
- `sleap.load_model()` now supports loading models from zip files to support core remote workflow.
- Massive refactor of the `sleap.nn.inference` submodule: deleted unused classes and methods and move a lot of functionality to the `Predictor` base class.
- Predictors now use `tf.keras.Model.predict_on_batch()` in inference loops to drastically improve speed by cached traced/autographed model call every batch.
- Inference now supports progress reporting using [`rich`](https://github.com/willmcgugan/rich#progress-bars) or by outputting JSON-encoded updates to `stdout` which can be captured by any caller. FPS and ETA are now calculated using a recent rolling buffer for more accurate estimates without needing to wait for startup/autograph amortization.
- Reworked inference CLI (`sleap-track`) to make it much, much clearer and follow a more linear workflow. Deprecated many redundant args (still supported but hidden from `sleap-track -h`).
- Inference CLI now takes a video or labels file as the positional `data_path` argument (e.g., `sleap-track -m path/to/model 
"labels.slp"`) without using the `--labels` flag.
- Inference CLI now uses a single `LabelsReader`/`VideoReader` provider to iterate over all inference targets. Previously, this was restarted per video, slowing down the whole process.
- Inference on suggestions now only predicts on suggestions associated with unlabeled frames.
- Inference CLI now stores much more metadata in `Labels.provenance` before saving, including system info, paths, sleap version, timestamps, etc.
- `TrainingJobConfig` now caches the sleap version and filename it was loaded from and saved to during I/O ops

## Fixes
- Instance counting no longer double counts `Instances`/`PredictedInstances`. This affects the model folder auto-naming, labeled instance count in suggestions table and more.
- `sleap-label` will now run in CPU-only mode to prevent pre-allocating all the GPU memory if any tensorflow ops are called.
- `sleap.load_model()` will now default to disabling pre-allocation of all the GPU memory even if called interactively to prevent the same issue.
- Fix dataset splitting to ensure there is a minimum of one sample per train/val split. Supports training with a single(!) label now.
- Suggestions row is now selected appropriately when navigating suggestions.