### PR TITLE
Appendix to the fix for issue #480

### DIFF
--- a/sleap/nn/data/providers.py
+++ b/sleap/nn/data/providers.py
@@ -34,10 +34,8 @@ class LabelsReader:
     @classmethod
     def from_user_instances(cls, labels: sleap.Labels) -> "LabelsReader":
         """Create a `LabelsReader` using the user instances in a `Labels` set.
-
         Args:
             labels: A `sleap.Labels` instance containing user instances.
-
         Returns:
             A `LabelsReader` instance that can create a dataset for pipelining.
         """
@@ -48,13 +46,10 @@ class LabelsReader:
     @classmethod
     def from_user_labeled_frames(cls, labels: sleap.Labels) -> "LabelsReader":
         """Create a `LabelsReader` using the user labeled frames in a `Labels` set.
-
         Args:
             labels: A `sleap.Labels` instance containing user labeled frames.
-
         Returns:
             A `LabelsReader` instance that can create a dataset for pipelining.
-
             Note that this constructor will load ALL instances in frames that have user
             instances. To load only user labeled indices, use
             `LabelsReader.from_user_instances`.
@@ -64,10 +59,8 @@ class LabelsReader:
     @classmethod
     def from_unlabeled_suggestions(cls, labels: sleap.Labels) -> "LabelsReader":
         """Create a `LabelsReader` using the unlabeled suggestions in a `Labels` set.
-
         Args:
             labels: A `sleap.Labels` instance containing unlabeled suggestions.
-
         Returns:
             A `LabelsReader` instance that can create a dataset for pipelining.
         """
@@ -112,12 +105,19 @@ class LabelsReader:
             "scale",
             "instances",
             "skeleton_inds",
+            "track_inds",
+            "n_tracks",
         ]
 
     @property
     def videos(self) -> List[sleap.Video]:
         """Return the list of videos that `video_ind` in examples match up with."""
         return self.labels.videos
+
+    @property
+    def tracks(self) -> List[sleap.Track]:
+        """Return the list of tracks that `track_inds` in examples match up with."""
+        return self.labels.tracks
 
     @property
     def max_height_and_width(self) -> Tuple[int, int]:
@@ -138,7 +138,6 @@ class LabelsReader:
         self, ds_index: Optional[tf.data.Dataset] = None
     ) -> tf.data.Dataset:
         """Return a `tf.data.Dataset` whose elements are data from labeled frames.
-
         Returns:
             A dataset whose elements are dictionaries with the loaded data associated
             with a single `LabeledFrame`. Items will be converted to tensors. These are:
@@ -165,6 +164,9 @@ class LabelsReader:
                     containing all of the instances in the frame.
                 "skeleton_inds": Tensor of shape (n_instances,) of dtype tf.int32 that
                     specifies the index of the skeleton used for each instance.
+                "track_inds": Tensor of shape (n_instance,) of dtype tf.int32 that
+                    specifies the index of the instance track identity. If not
+                    specified, in the labels, this is set to -1.
         """
         # Grab the first image to capture dtype and number of color channels.
         first_image = tf.convert_to_tensor(self.labels[0].image)
@@ -196,6 +198,13 @@ class LabelsReader:
             skeleton_inds = np.array(
                 [self.labels.skeletons.index(inst.skeleton) for inst in insts]
             ).astype("int32")
+            track_inds = np.array(
+                [
+                    self.tracks.index(inst.track) if inst.track is not None else -1
+                    for inst in insts
+                ]
+            ).astype("int32")
+            n_tracks = np.array(len(self.tracks)).astype("int32")
             return (
                 raw_image,
                 raw_image_size,
@@ -203,6 +212,8 @@ class LabelsReader:
                 video_ind,
                 frame_ind,
                 skeleton_inds,
+                track_inds,
+                n_tracks,
             )
 
         def fetch_lf(ind):
@@ -215,10 +226,21 @@ class LabelsReader:
                 video_ind,
                 frame_ind,
                 skeleton_inds,
+                track_inds,
+                n_tracks,
             ) = tf.py_function(
                 py_fetch_lf,
                 [ind],
-                [image_dtype, tf.int32, tf.float32, tf.int32, tf.int64, tf.int32],
+                [
+                    image_dtype,
+                    tf.int32,
+                    tf.float32,
+                    tf.int32,
+                    tf.int64,
+                    tf.int32,
+                    tf.int32,
+                    tf.int32,
+                ],
             )
 
             # Ensure shape with constant or variable height/width, based on whether or
@@ -230,6 +252,7 @@ class LabelsReader:
 
             instances = tf.ensure_shape(instances, tf.TensorShape([None, None, 2]))
             skeleton_inds = tf.ensure_shape(skeleton_inds, tf.TensorShape([None]))
+            track_inds = tf.ensure_shape(track_inds, tf.TensorShape([None]))
 
             return {
                 "image": image,
@@ -240,6 +263,8 @@ class LabelsReader:
                 "scale": tf.ones([2], dtype=tf.float32),
                 "instances": instances,
                 "skeleton_inds": skeleton_inds,
+                "track_inds": track_inds,
+                "n_tracks": n_tracks,
             }
 
         if self.example_indices is None:


### PR DESCRIPTION
### Description
Pre-allocate the instances array (even if the first axis has a size of 0). This results in an array that always has rank-3, even when there are no instances, and we don't get an error when trying to stack an empty list.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
https://github.com/murthylab/sleap/issues/480