### PR TITLE
Add support for specifying the minimum score in PAF matching

### DIFF
--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -2348,6 +2348,9 @@ class BottomUpPredictor(Predictor):
             in relative image units. Candidate connections above this length will be
             penalized during matching.
         paf_line_points: Number of points to sample along the line integral.
+        min_line_scores: Minimum line score (between -1 and 1) required to form a match
+            between candidate point pairs. Useful for rejecting spurious detections when
+            there are no better ones.
     """
 
     bottomup_config: TrainingJobConfig
@@ -2361,6 +2364,7 @@ class BottomUpPredictor(Predictor):
     integral_patch_size: int = 5
     max_edge_length_ratio: float = 0.5
     paf_line_points: int = 10
+    min_line_scores: float = 0.25
 
     def _initialize_inference_model(self):
         """Initialize the inference model from the trained model and configuration."""
@@ -2372,6 +2376,7 @@ class BottomUpPredictor(Predictor):
                     max_edge_length_ratio=self.max_edge_length_ratio,
                     n_points=self.paf_line_points,
                     min_instance_peaks=0,
+                    min_line_scores=self.min_line_scores,
                 ),
                 input_scale=self.bottomup_config.data.preprocessing.input_scaling,
                 pad_to_stride=self.bottomup_model.maximum_stride,
@@ -2389,6 +2394,9 @@ class BottomUpPredictor(Predictor):
         peak_threshold: float = 0.2,
         integral_refinement: bool = True,
         integral_patch_size: int = 5,
+        max_edge_length_ratio: float = 0.5,
+        paf_line_points: int = 10,
+        min_line_scores: float = 0.25,
     ) -> "BottomUpPredictor":
         """Create predictor from a saved model.
 
@@ -2407,6 +2415,13 @@ class BottomUpPredictor(Predictor):
                 offset regression head.
             integral_patch_size: Size of patches to crop around each rough peak for
                 integral refinement as an integer scalar.
+            max_edge_length_ratio: The maximum expected length of a connected pair of
+                points in relative image units. Candidate connections above this length
+                will be penalized during matching.
+            paf_line_points: Number of points to sample along the line integral.
+            min_line_scores: Minimum line score (between -1 and 1) required to form a
+                match between candidate point pairs. Useful for rejecting spurious
+                detections when there are no better ones.
 
         Returns:
             An instance of `BottomUpPredictor` with the loaded model.
@@ -2425,6 +2440,9 @@ class BottomUpPredictor(Predictor):
             integral_refinement=integral_refinement,
             integral_patch_size=integral_patch_size,
             batch_size=batch_size,
+            max_edge_length_ratio=max_edge_length_ratio,
+            paf_line_points=paf_line_points,
+            min_line_scores=min_line_scores,
         )
         obj._initialize_inference_model()
         return obj

--- a/sleap/nn/paf_grouping.py
+++ b/sleap/nn/paf_grouping.py
@@ -929,7 +929,7 @@ def group_instances_sample(
     n_edges: int,
     edge_types: List[EdgeType],
     min_instance_peaks: int,
-    min_line_scores: float = 0.25
+    min_line_scores: float = 0.25,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Group matched connections into full instances for a single sample.
 
@@ -996,7 +996,6 @@ def group_instances_sample(
         match_dst_peak_inds_sample = match_dst_peak_inds_sample.numpy()
         match_line_scores_sample = match_line_scores_sample.numpy()
 
-
     # Filter out low scoring matches.
     is_valid_match = match_line_scores_sample >= min_line_scores
     match_edge_inds_sample = match_edge_inds_sample[is_valid_match]
@@ -1061,7 +1060,7 @@ def group_instances_batch(
     n_edges: int,
     edge_types: List[EdgeType],
     min_instance_peaks: int,
-    min_line_scores: float = 0.25
+    min_line_scores: float = 0.25,
 ) -> Tuple[tf.RaggedTensor, tf.RaggedTensor, tf.RaggedTensor]:
     """Group matched connections into full instances for a batch.
 
@@ -1245,6 +1244,9 @@ class PAFScorer:
         min_instance_peaks: Minimum number of peaks the instance should have to be
             considered a real instance. Instances with fewer peaks than this will be
             discarded (useful for filtering spurious detections).
+        min_line_scores: Minimum line score (between -1 and 1) required to form a match
+            between candidate point pairs. Useful for rejecting spurious detections when
+            there are no better ones.
         edge_inds: The edges of the skeleton defined as a list of (source, destination)
             tuples of node indices. This is created automatically on initialization.
         edge_types: A list of `EdgeType` instances representing the edges of the
@@ -1309,6 +1311,7 @@ class PAFScorer:
         max_edge_length_ratio: float = 0.5,
         n_points: int = 10,
         min_instance_peaks: Union[int, float] = 0,
+        min_line_scores: float = 0.25,
     ) -> "PAFScorer":
         """Initialize the PAF scorer from a `MultiInstanceConfig` head config.
 
@@ -1322,6 +1325,9 @@ class PAFScorer:
             min_instance_peaks: Minimum number of peaks the instance should have to be
                 considered a real instance. Instances with fewer peaks than this will be
                 discarded (useful for filtering spurious detections).
+            min_line_scores: Minimum line score (between -1 and 1) required to form a
+                match between candidate point pairs. Useful for rejecting spurious
+                detections when there are no better ones.
 
         Returns:
             The initialized instance of `PAFScorer`.
@@ -1333,6 +1339,7 @@ class PAFScorer:
             max_edge_length_ratio=max_edge_length_ratio,
             n_points=n_points,
             min_instance_peaks=min_instance_peaks,
+            min_line_scores=min_line_scores,
         )
 
     def score_paf_lines(
@@ -1511,7 +1518,7 @@ class PAFScorer:
             self.n_edges,
             self.edge_types,
             self.min_instance_peaks,
-            min_line_scores=self.min_line_scores
+            min_line_scores=self.min_line_scores,
         )
 
     def predict(

--- a/tests/nn/test_inference.py
+++ b/tests/nn/test_inference.py
@@ -529,7 +529,7 @@ def test_topdown_predictor_centered_instance(
     assert_allclose(points_gt[inds1.numpy()], points_pr[inds2.numpy()], atol=1.5)
 
 
-def test_topdown_predictor_bottomup(min_labels, min_bottomup_model_path):
+def test_bottomup_predictor(min_labels, min_bottomup_model_path):
     predictor = BottomUpPredictor.from_trained_models(
         model_path=min_bottomup_model_path
     )
@@ -545,6 +545,14 @@ def test_topdown_predictor_bottomup(min_labels, min_bottomup_model_path):
     )
     inds1, inds2 = sleap.nn.utils.match_points(points_gt, points_pr)
     assert_allclose(points_gt[inds1.numpy()], points_pr[inds2.numpy()], atol=1.75)
+
+    # Test inference with score threshold too high
+    predictor = BottomUpPredictor.from_trained_models(
+        model_path=min_bottomup_model_path,
+        min_line_scores=1.1,
+    )
+    labels_pr = predictor.predict(min_labels)
+    assert len(labels_pr[0]) == 0
 
 
 def test_load_model(

--- a/tests/nn/test_paf_grouping.py
+++ b/tests/nn/test_paf_grouping.py
@@ -173,7 +173,7 @@ def test_group_instances_sample():
     match_edge_inds_sample = tf.constant([0, 1, 0], tf.int32)
     match_src_peak_inds_sample = tf.constant([0, 0, 1], tf.int32)
     match_dst_peak_inds_sample = tf.constant([0, 0, 1], tf.int32)
-    match_line_scores_sample = tf.range(3, dtype=tf.float32)
+    match_line_scores_sample = tf.ones([3], dtype=tf.float32)
     n_nodes = 3
     n_edges = 2
     edge_types = [EdgeType(0, 1), EdgeType(1, 2)]
@@ -209,7 +209,7 @@ def test_group_instances_sample():
         ],
     )
     assert_array_equal(predicted_peak_scores, [[0.0, 1.0, 2.0], [3.0, 4.0, np.nan]])
-    assert_array_equal(predicted_instance_scores, [1.0, 2.0])
+    assert_array_equal(predicted_instance_scores, [2.0, 1.0])
 
 
 def test_group_instances_batch():
@@ -234,7 +234,7 @@ def test_group_instances_batch():
         tf.constant([0, 0, 1], tf.int32), row_ids_edges
     )
     match_line_scores = tf.RaggedTensor.from_value_rowids(
-        tf.range(3, dtype=tf.float32), row_ids_edges
+        tf.ones([3], dtype=tf.float32), row_ids_edges
     )
     n_nodes = 3
     n_edges = 2
@@ -277,4 +277,4 @@ def test_group_instances_batch():
     assert_array_equal(
         predicted_peak_scores.flat_values, [[0.0, 1.0, 2.0], [3.0, 4.0, np.nan]]
     )
-    assert_array_equal(predicted_instance_scores.flat_values, [1.0, 2.0])
+    assert_array_equal(predicted_instance_scores.flat_values, [2.0, 1.0])


### PR DESCRIPTION
### Description
Add support for thresholding PAF matches in bottom-up inference.

Effective at filtering out explicitly spurious matches when no better match is available.

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
N/A

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/murthylab/sleap/wiki/Developer-Guide) to this repository
- [ ] Read and sign the [CLA](https://github.com/murthylab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/murthylab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
