### PR TITLE
Fix post-training errors

### DIFF
--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -578,7 +578,7 @@ class LearningDialog(QtWidgets.QDialog):
         self._handle_learning_finished.emit(new_counts)
 
         # count < 0 means there was an error and we didn't get any results.
-        if new_counts >= 0:
+        if new_counts is not None and new_counts >= 0:
             total_count = items_for_inference.total_frame_count
             no_result_count = total_count - new_counts
 

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -651,7 +651,7 @@ def run_gui_inference(
             msg = "Predicting..."
 
             if n_processed is not None and n_total is not None:
-                msg = f"Predicted: <b>{n_processed:,}/{n_total:,}</b>"
+                msg = f"<b>Predicted:</b> {n_processed:,}/{n_total:,}"
 
             # Show time elapsed?
             if rate is not None and eta is not None:
@@ -663,8 +663,8 @@ def run_gui_inference(
                     eta_str = f"{int(eta_mins)} mins, {int(eta_secs):02} secs"
                 else:
                     eta_str = f"{int(eta_secs):02} secs"
-                msg += f"<br>ETA: <b>{eta_str}</b>"
-                msg += f"<br>FPS: <b>{rate:.1f}</b>"
+                msg += f"<br><b>ETA:</b> {eta_str}"
+                msg += f"<br><b>FPS:</b> {rate:.1f}"
 
             msg = msg.replace(" ", "&nbsp;")
 

--- a/sleap/nn/training.py
+++ b/sleap/nn/training.py
@@ -936,8 +936,15 @@ class Trainer(ABC):
         """Delete visualization images subdirectory."""
         viz_path = os.path.join(self.run_path, "viz")
         if os.path.exists(viz_path):
-            logger.info(f"Deleting visualization directory: {viz_path}")
-            shutil.rmtree(viz_path)
+            try:
+                logger.info(f"Deleting visualization directory: {viz_path}")
+                shutil.rmtree(viz_path)
+            except PermissionError:
+                logger.info(
+                    "Failed to delete visualization directory. If you are training "
+                    "through the GUI, this is likely because the visualizer was "
+                    "checking for new images. Delete the directory manually if needed."
+                )
 
     def package(self):
         """Package model folder into a zip file for portability."""


### PR DESCRIPTION
### Description
- Catch filesystem busy error when deleting viz dir (#500)
- Don't throw an error after training with no inference target

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
#500

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/murthylab/sleap/wiki/Developer-Guide) to this repository
- [ ] Read and sign the [CLA](https://github.com/murthylab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/murthylab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
