### PR TITLE
Remove size matching twice in centroid training viz pipeline building

### DIFF
--- a/sleap/nn/data/pipelines.py
+++ b/sleap/nn/data/pipelines.py
@@ -604,11 +604,6 @@ class CentroidConfmapsPipeline:
         """
         pipeline = self.make_base_pipeline(data_provider=data_provider)
         pipeline += Prefetcher()
-        if self.data_config.preprocessing.resize_and_pad_to_target:
-            pipeline += SizeMatcher.from_config(
-                config=self.data_config.preprocessing,
-                provider=data_provider,
-            )
         pipeline += Repeater()
         if self.optimization_config.augmentation_config.random_crop:
             pipeline += RandomCropper(


### PR DESCRIPTION
### Description
Remove size matching twice in centroid training viz pipeline building

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
#517 
#510 

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/murthylab/sleap/wiki/Developer-Guide) to this repository
- [ ] Read and sign the [CLA](https://github.com/murthylab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/murthylab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
