### PR TITLE
Fix SizeMatcher inference scaling

### DIFF
--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -274,6 +274,11 @@ class Predictor(ABC):
             if isinstance(ex["frame_ind"], tf.Tensor):
                 ex["frame_ind"] = ex["frame_ind"].numpy().flatten()
 
+            # Adjust for potential SizeMatcher scaling.
+            ex["instance_peaks"] /= np.expand_dims(
+                np.expand_dims(ex["scale"], axis=1), axis=1
+            )
+
             return ex
 
         # Loop over data batches with optional progress reporting.

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -45,7 +45,7 @@ import tensorflow as tf
 import numpy as np
 
 import sleap
-from sleap.nn.config import TrainingJobConfig
+from sleap.nn.config import TrainingJobConfig, DataConfig
 from sleap.nn.data.resizing import SizeMatcher
 from sleap.nn.model import Model
 from sleap.nn.tracking import Tracker
@@ -195,7 +195,7 @@ class Predictor(ABC):
 
     @property
     @abstractmethod
-    def data_config(self):
+    def data_config(self) -> DataConfig:
         pass
 
     def make_pipeline(self, data_provider: Optional[Provider] = None) -> Pipeline:
@@ -404,7 +404,7 @@ class VisualPredictor(Predictor):
     pipeline: Optional[Pipeline] = attr.ib(default=None, init=False)
 
     @property
-    def data_config(self):
+    def data_config(self) -> DataConfig:
         return self.config.data
 
     @classmethod
@@ -1124,7 +1124,7 @@ class SingleInstancePredictor(Predictor):
         )
 
     @property
-    def data_config(self):
+    def data_config(self) -> DataConfig:
         return self.confmap_config.data
 
     @classmethod
@@ -1842,7 +1842,7 @@ class TopDownPredictor(Predictor):
         )
 
     @property
-    def data_config(self):
+    def data_config(self) -> DataConfig:
         return (
             self.centroid_config.data
             if self.centroid_config
@@ -2430,7 +2430,7 @@ class BottomUpPredictor(Predictor):
         )
 
     @property
-    def data_config(self):
+    def data_config(self) -> DataConfig:
         return self.bottomup_config.data
 
     @classmethod

--- a/sleap/nn/training.py
+++ b/sleap/nn/training.py
@@ -1042,7 +1042,7 @@ class SingleInstanceModelTrainer(Trainer):
             preds = inference_layer(tf.expand_dims(img, axis=0))
             cms = preds["confmaps"].numpy()[0]
             pts_gt = example["instances"].numpy()[0]
-            pts_pr = preds["peaks"].numpy()[0]
+            pts_pr = preds["instance_peaks"].numpy()[0][0]
 
             scale = 1.0
             if img.shape[0] < 512:

--- a/tests/nn/test_inference.py
+++ b/tests/nn/test_inference.py
@@ -451,12 +451,19 @@ def test_single_instance_inference():
     assert layer.output_stride == 1
 
     out = layer(cms)
-    assert_array_equal(out["peaks"], points)
-    assert_allclose(out["peak_vals"], 1.0, atol=0.1)
+
+    assert tuple(out["instance_peaks"].shape) == (2, 1, 3, 2)
+    out["instance_peaks"] = tf.squeeze(out["instance_peaks"], axis=1)
+    assert tuple(out["instance_peak_vals"].shape) == (2, 1, 3)
+    out["instance_peak_vals"] = tf.squeeze(out["instance_peak_vals"], axis=1)
+    assert_array_equal(out["instance_peaks"], points)
+    assert_allclose(out["instance_peak_vals"], 1.0, atol=0.1)
     assert "confmaps" not in out
 
     out = layer({"image": cms})
-    assert_array_equal(out["peaks"], points)
+    assert tuple(out["instance_peaks"].shape) == (2, 1, 3, 2)
+    out["instance_peaks"] = tf.squeeze(out["instance_peaks"], axis=1)
+    assert_array_equal(out["instance_peaks"], points)
 
     layer = SingleInstanceInferenceLayer(
         keras_model=keras_model, refinement="local", return_confmaps=True
@@ -467,8 +474,10 @@ def test_single_instance_inference():
 
     model = SingleInstanceInferenceModel(layer)
     preds = model.predict(cms)
-    assert_array_equal(preds["peaks"], points)
-    assert "peak_vals" in preds
+    assert preds["instance_peaks"].shape == (2, 1, 3, 2)
+    preds["instance_peaks"] = preds["instance_peaks"].squeeze(axis=1)
+    assert_array_equal(preds["instance_peaks"], points)
+    assert "instance_peak_vals" in preds
     assert "confmaps" in preds
 
 


### PR DESCRIPTION
### Description
This fixes an issue where using `SizeMatcher` that has a preset height/width that is of a different aspect ratio to the input results in peaks that are scaled incorrectly.

Now peaks are always scaled by the `"scale"` key (which defaults to 1.0 anyway when not using the `SizeMatcher`.)

**Breaking:** Single instance inference layer/model now outputs `"instance_peaks"` and `"instance_peak_vals"` with shape `(samples, 1, nodes, 2)` and `(samples, 1, nodes)`, which matches all the other multi-instance models. Previously, these did not have a singleton dimension and were stored in `"peaks"` and `"peak_vals"` keys.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
#516

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/murthylab/sleap/wiki/Developer-Guide) to this repository
- [ ] Read and sign the [CLA](https://github.com/murthylab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/murthylab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
