### PR TITLE
fix code samples in documentation

### DIFF
--- a/sleap/gui/dialogs/formbuilder.py
+++ b/sleap/gui/dialogs/formbuilder.py
@@ -6,17 +6,17 @@ the widget as a model dialog, :py:class:`FormBuilderModalDialog` makes this
 a little more convenient (it provides methods for adding a message for the
 dialog and for getting the results when the dialog is closed).
 
-Example of form widget:
+Example of form widget: ::
 
->>> widget = YamlFormWidget(yaml_file="example.yaml")
->>> widget.mainAction.connect(my_function)
+   >>> widget = YamlFormWidget(yaml_file="example.yaml")
+   >>> widget.mainAction.connect(my_function)
 
 my_function will get called with form data when user clicks the main button
 (main button has type "button" and default "main action")
 
-Example of modal dialog:
+Example of modal dialog: ::
 
->>> results = FormBuilderModalDialog(form_name="example").get_results()
+   >>> results = FormBuilderModalDialog(form_name="example").get_results()
 
 The results will be empty dictionary if the user hit "cancel", otherwise it
 will contain all data from form (dict keys matching names of fields).
@@ -43,9 +43,9 @@ class YamlFormWidget(QtWidgets.QGroupBox):
 
     Typically you'll want to save the YAML in `sleap/config/` and use the
     :py:meth:`from_name` method to make the form (e.g., if your form data is in
-    `sleap/config/foo.yaml`, then you can create form like so:
+    `sleap/config/foo.yaml`, then you can create form like so: ::
 
-    >>> widget = YamlFormWidget.from_name("foo")
+       >>> widget = YamlFormWidget.from_name("foo")
 
     Args:
         yaml_file: filename of YAML file to load.

--- a/sleap/gui/dialogs/importvideos.py
+++ b/sleap/gui/dialogs/importvideos.py
@@ -1,9 +1,9 @@
 """
 Interface to handle the UI for importing videos.
 
-Usage:
+Usage: ::
 
->>> import_list = ImportVideos().ask()
+   >>> import_list = ImportVideos().ask()
 
 This will show the user a file-selection dialog, and then a second dialog
 to select the import parameters for each file.
@@ -14,9 +14,9 @@ relevant for that specific type of file. It also includes a reference
 to the relevant method of :class:`Video`.
 
 For each `item` in `import_list`, we can load the video by calling this
-method while passing the user-selected params as the named parameters:
+method while passing the user-selected params as the named parameters: ::
 
->>> vid = item["video_class"](**item["params"])
+   >>> vid = item["video_class"](**item["params"])
 
 """
 

--- a/sleap/gui/overlays/confmaps.py
+++ b/sleap/gui/overlays/confmaps.py
@@ -5,9 +5,11 @@ Currently a `DataOverlay` gets data from a model (i.e., it runs inference on the
 current frame) and then uses a `ConfMapsPlot` object to show the resulting
 confidence maps.
 
-Example:
+Example: ::
+
     >>> cm = ConfMapsPlot(conf_data.get_frame(0))
     >>> window.view.scene.addItem(cm)
+
 """
 
 from PySide2 import QtWidgets, QtCore, QtGui

--- a/sleap/gui/widgets/multicheck.py
+++ b/sleap/gui/widgets/multicheck.py
@@ -1,10 +1,12 @@
 """
 Module for Qt Widget to show multiple checkboxes for selecting.
 
-Example:
+Example: ::
+
     >>> mc = MultiCheckWidget(count=5, selected=[0,1],title="My Items")
     >>> mc.selectionChanged.connect(window.plot)
     >>> window.layout.addWidget(mc)
+
 """
 
 from typing import List, Optional

--- a/sleap/gui/widgets/video.py
+++ b/sleap/gui/widgets/video.py
@@ -3,7 +3,8 @@ Module for showing and manipulating skeleton instances within a video.
 
 All interactions should go through `QtVideoPlayer`.
 
-Example usage:
+Example usage: ::
+
     >>> my_video = Video(...)
     >>> my_instance = Instance(...)
 
@@ -523,8 +524,9 @@ class QtVideoPlayer(QWidget):
         selection), the `on_failure` callback is called (if given).
 
         Note:
-            If successful, we call
-            >>> on_success(list_of_instances)
+            If successful, we call ::
+
+               >>> on_success(list_of_instances)
 
         Args:
             seq_len: Number of instances we want to collect in sequence.

--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -5,33 +5,33 @@ This contains labeled frame data (user annotations and/or predictions),
 together with all the other data that is saved for a SLEAP project
 (videos, skeletons, etc.).
 
-The most convenient way to load SLEAP labels files is to use the high level loader:
+The most convenient way to load SLEAP labels files is to use the high level loader: ::
 
-> import sleap
-> labels = sleap.load_file(filename)
+   > import sleap
+   > labels = sleap.load_file(filename)
 
 The Labels class provides additional functionality for loading SLEAP labels files. To
-load a labels dataset file from disk:
+load a labels dataset file from disk: ::
 
-> labels = Labels.load_file(filename)
+   > labels = Labels.load_file(filename)
 
 If you're opening a dataset file created on a different computer (or if you've
 moved the video files), it's likely that the paths to the original videos will
 not work. We automatically check for the videos in the same directory as the
 labels file, but if the videos aren't there, you can tell `load_file` where
-to search for the videos. There are various ways to do this:
+to search for the videos. There are various ways to do this: ::
 
-> Labels.load_file(filename, single_path_to_search)
-> Labels.load_file(filename, [path_a, path_b])
-> Labels.load_file(filename, callback_function)
-> Labels.load_file(filename, video_search=...)
+   > Labels.load_file(filename, single_path_to_search)
+   > Labels.load_file(filename, [path_a, path_b])
+   > Labels.load_file(filename, callback_function)
+   > Labels.load_file(filename, video_search=...)
 
 The callback_function can be created via `make_video_callback()` and has the
 option to make a callback with a GUI window so the user can locate the videos.
 
-To save a labels dataset file, run:
+To save a labels dataset file, run: ::
 
-> Labels.save_file(labels, filename)
+   > Labels.save_file(labels, filename)
 
 If the filename has a supported extension (e.g., ".slp", ".h5", ".json") then
 the file will be saved in the corresponding format. You can also specify the

--- a/sleap/io/video.py
+++ b/sleap/io/video.py
@@ -926,14 +926,14 @@ class Video:
     components. This interface currently only supports reading of video
     data, there is no write support. Unless one is creating a new video
     backend, this class should be instantiated from its various class methods
-    for different formats. For example:
+    for different formats. For example: ::
 
-    >>> video = Video.from_hdf5(filename="test.h5", dataset="box")
-    >>> video = Video.from_media(filename="test.mp4")
+       >>> video = Video.from_hdf5(filename="test.h5", dataset="box")
+       >>> video = Video.from_media(filename="test.mp4")
 
-    Or we can use auto-detection based on filename:
+    Or we can use auto-detection based on filename: ::
 
-    >>> video = Video.from_filename(filename="test.mp4")
+       >>> video = Video.from_filename(filename="test.mp4")
 
     Args:
         backend: A backend is an object that implements the following basic
@@ -1549,7 +1549,8 @@ def load_video(
 
         This enables numpy-like access to video data.
 
-    Example:
+    Example: ::
+
         >>> video = sleap.load_video("centered_pair_small.mp4")
         >>> video.shape
         (1100, 384, 384, 1)

--- a/sleap/io/videowriter.py
+++ b/sleap/io/videowriter.py
@@ -1,11 +1,12 @@
 """
 Module for writing avi/mp4 videos.
 
-Usage:
+Usage: ::
 
-> writer = VideoWriter.safe_builder(filename, height, width, fps)
-> writer.add_frame(img)
-> writer.close()
+   > writer = VideoWriter.safe_builder(filename, height, width, fps)
+   > writer.add_frame(img)
+   > writer.close()
+
 """
 
 from abc import ABC, abstractmethod

--- a/sleap/nn/evals.py
+++ b/sleap/nn/evals.py
@@ -3,11 +3,11 @@ Evaluation utilities for measuring pose estimation accuracy.
 
 To generate metrics, you'll need two `Labels` datasets, one with ground truth
 data and one with predicted data. The video paths in the datasets must match.
-Load both datasets and call `evaluate`, like so:
+Load both datasets and call `evaluate`, like so: ::
 
-> labels_gt = Labels.load_file("path/to/ground/truth.slp")
-> labels_pr = Labels.load_file("path/to/predictions.slp")
-> metrics = evaluate(labels_gt, labels_pr)
+   > labels_gt = Labels.load_file("path/to/ground/truth.slp")
+   > labels_pr = Labels.load_file("path/to/predictions.slp")
+   > metrics = evaluate(labels_gt, labels_pr)
 
 `evaluate` returns a dictionary, keys are strings which name the metric,
 values are either floats or numpy arrays.

--- a/sleap/nn/peak_finding.py
+++ b/sleap/nn/peak_finding.py
@@ -109,7 +109,8 @@ def find_offsets_local_direction(
         This is a commonly used algorithm for subpixel peak refinement, described for
         pose estimation applications in [1].
 
-    Example:
+    Example: ::
+
         >>> find_offsets_local_direction(np.array(
         ...     [[0., 1., 0.],
         ...      [1., 3., 2.],

--- a/sleap/nn/utils.py
+++ b/sleap/nn/utils.py
@@ -28,9 +28,11 @@ def group_array(
         <https://jakevdp.github.io/blog/2017/03/22/group-by-from-scratch/>`
         for performance comparisons of different approaches.
 
-    Example:
+    Example: ::
+
         >>> group_array(np.arange(5), np.array([1, 5, 2, 1, 5]))
         {1: array([0, 3]), 5: array([1, 4]), 2: array([2])}
+
     """
 
     group_inds = defaultdict(list)

--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -266,10 +266,10 @@ class Skeleton:
 
         This property is immutable because it is used to hash skeletons.
         If you want to rename a Skeleton you must use the class
-        method :code:`rename_skeleton`:
+        method :code:`rename_skeleton`: ::
 
-        >>> new_skeleton = Skeleton.rename_skeleton(
-        >>>     skeleton=old_skeleton, name="New Name")
+           >>> new_skeleton = Skeleton.rename_skeleton(
+           >>>     skeleton=old_skeleton, name="New Name")
 
         Args:
             name: The name of the Skeleton.
@@ -289,10 +289,10 @@ class Skeleton:
         """Make copy of skeleton with new name.
 
         This property is immutable because it is used to hash skeletons.
-        If you want to rename a Skeleton you must use this class method.
+        If you want to rename a Skeleton you must use this class method. ::
 
-        >>> new_skeleton = Skeleton.rename_skeleton(
-        >>>     skeleton=old_skeleton, name="New Name")
+           >>> new_skeleton = Skeleton.rename_skeleton(
+           >>>     skeleton=old_skeleton, name="New Name")
 
         Args:
             skeleton: The skeleton to copy.


### PR DESCRIPTION
The code samples to render properly have to be valid rst literal blocks (https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#literal-blocks). The most affected are multi-line code samples that are joined to a singe line, see https://sleap.ai/api/sleap.io.dataset.html.

The leading "   > " could be possibly removed to make copying the snippets easy.