### PR TITLE
Fix single instance predictor not using peak threshold param

### DIFF
--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -1122,6 +1122,7 @@ class SingleInstancePredictor(Predictor):
                 keras_model=self.confmap_model.keras_model,
                 input_scale=self.confmap_config.data.preprocessing.input_scaling,
                 pad_to_stride=self.confmap_model.maximum_stride,
+                peak_threshold=self.peak_threshold,
                 refinement="integral" if self.integral_refinement else "local",
                 integral_patch_size=self.integral_patch_size,
             )

--- a/tests/nn/test_inference.py
+++ b/tests/nn/test_inference.py
@@ -500,6 +500,18 @@ def test_single_instance_predictor(
     assert_allclose(points_gt, points_pr, atol=10.0)
 
 
+def test_single_instance_predictor_high_peak_thresh(
+    min_labels_robot, min_single_instance_robot_model_path
+):
+    predictor = SingleInstancePredictor.from_trained_models(
+        min_single_instance_robot_model_path, peak_threshold=1.5
+    )
+    labels_pr = predictor.predict(min_labels_robot)
+    assert len(labels_pr) == 2
+    assert labels_pr[0][0].n_visible_points == 0
+    assert labels_pr[1][0].n_visible_points == 0
+
+
 def test_topdown_predictor_centroid(min_labels, min_centroid_model_path):
     predictor = TopDownPredictor.from_trained_models(
         centroid_model_path=min_centroid_model_path


### PR DESCRIPTION
### Description
Fix single instance predictor not using the peak threshold when specified.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
N/A

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/murthylab/sleap/wiki/Developer-Guide) to this repository
- [ ] Read and sign the [CLA](https://github.com/murthylab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/murthylab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
