### PR TITLE
Skeleton merge conflicts

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1505,7 +1505,13 @@ class SetNodeName(EditCommand):
         node = params["node"]
         name = params["name"]
         skeleton = params["skeleton"]
-        skeleton.relabel_node(node.name, name)
+
+        if name in skeleton.node_names:
+            # Merge
+            context.labels.merge_nodes(name, node.name)
+        else:
+            # Simple relabel
+            skeleton.relabel_node(node.name, name)
 
 
 class SetNodeSymmetry(EditCommand):

--- a/sleap/gui/dialogs/merge.py
+++ b/sleap/gui/dialogs/merge.py
@@ -40,8 +40,27 @@ class MergeDialog(QtWidgets.QDialog):
 
         super(MergeDialog, self).__init__(*args, **kwargs)
 
+        layout = QtWidgets.QVBoxLayout()
+
         self.base_labels = base_labels
         self.new_labels = new_labels
+
+        if self.base_labels.skeleton.node_names != self.new_labels.skeleton.node_names:
+            # Warn about mismatching skeletons
+            base_nodes = self.base_labels.skeleton.node_names
+            merge_nodes = self.new_labels.skeleton.node_names
+            missing_nodes = [node for node in base_nodes if node not in merge_nodes]
+            new_nodes = [node for node in merge_nodes if node not in base_nodes]
+            layout.addWidget(
+                QtWidgets.QLabel(
+                    "<p><strong>Warning:</strong> Skeletons do not match. "
+                    "The following nodes will be added to all instances:<p>"
+                    f"<p><em>From base labels</em>: {','.join(missing_nodes)}<br>"
+                    f"<em>From new labels</em>: {','.join(new_nodes)}</p>"
+                    "<p>Nodes can be deleted or merged from the skeleton editor after "
+                    "merging labels.</p><br>"
+                )
+            )
 
         merged, self.extra_base, self.extra_new = Labels.complex_merge_between(
             self.base_labels, self.new_labels
@@ -54,8 +73,6 @@ class MergeDialog(QtWidgets.QDialog):
             merge_frames += len(vid_frame_list.keys())
             # number of instances across frames for this video
             merge_total += sum((map(len, vid_frame_list.values())))
-
-        layout = QtWidgets.QVBoxLayout()
 
         merged_text = f"Cleanly merged {merge_total} instances"
         if merge_total:
@@ -298,15 +315,19 @@ def show_instance_type_counts(instance_list: List["Instance"]) -> str:
         list(filter(lambda inst: hasattr(inst, "score"), instance_list))
     )
     user_count = len(instance_list) - prediction_count
-    return f"{user_count}/{prediction_count}"
+    return f"{user_count} (user) / {prediction_count} (pred)"
 
 
 if __name__ == "__main__":
 
     #     file_a = "tests/data/json_format_v1/centered_pair.json"
     #     file_b = "tests/data/json_format_v2/centered_pair_predictions.json"
-    file_a = "files/merge/a.h5"
-    file_b = "files/merge/b.h5"
+    # file_a = "files/merge/a.h5"
+    # file_b = "files/merge/b.h5"
+    file_a = r"sleap_sandbox/skeleton_merge_conflicts/base_labels.slp"
+    # file_b = r"sleap_sandbox/skeleton_merge_conflicts/labels.renamed_node.slp")
+    # file_b = r"sleap_sandbox/skeleton_merge_conflicts/labels.new_node.slp"
+    file_b = r"sleap_sandbox/skeleton_merge_conflicts/labels.deleted_node.slp"
 
     base_labels = Labels.load_file(file_a)
     new_labels = Labels.load_file(file_b)

--- a/sleap/instance.py
+++ b/sleap/instance.py
@@ -954,6 +954,28 @@ class Instance:
         """
         return cls.from_pointsarray(points, skeleton, track=track)
 
+    def _merge_nodes_data(self, base_node: str, merge_node: str):
+        """Copy point data from one node to another.
+
+        Args:
+            base_node: Name of node that will be merged into.
+            merge_node: Name of node that will be removed after merge.
+
+        Notes:
+            This is used when merging skeleton nodes and should not be called directly.
+        """
+        base_pt = self[base_node]
+        merge_pt = self[merge_node]
+        if merge_pt.isnan():
+            return
+        if base_pt.isnan() or not base_pt.visible:
+            base_pt.x = merge_pt.x
+            base_pt.y = merge_pt.y
+            base_pt.visible = merge_pt.visible
+            base_pt.complete = merge_pt.complete
+            if hasattr(base_pt, "score"):
+                base_pt.score = merge_pt.score
+
 
 @attr.s(eq=False, order=False, slots=True, repr=False, str=False)
 class PredictedInstance(Instance):

--- a/sleap/instance.py
+++ b/sleap/instance.py
@@ -799,7 +799,9 @@ class Instance:
         w, h = y2 - y1, x2 - x1
         for node in self.skeleton.nodes:
             if node not in self.nodes or self[node].isnan():
-                x, y = np.random.rand(2) * np.array([w, h]) + np.array([x1, y1])
+                x, y = np.random.rand(2) * np.array([w + 2, h + 2]) + np.array(
+                    [x1 - 2, y1 - 2]
+                )
                 self[node] = Point(x=x, y=y, visible=False)
 
     @property

--- a/sleap/instance.py
+++ b/sleap/instance.py
@@ -544,6 +544,7 @@ class Instance:
             to each node.
 
         """
+        self._fix_array()
         # If the node is a list of nodes, use get item recursively and return a list of
         # _points.
         if isinstance(node, (list, tuple, np.ndarray)):
@@ -603,6 +604,7 @@ class Instance:
                 one of the inputs is a list.
             KeyError: If skeleton does not have (one of) the node(s).
         """
+        self._fix_array()
         # Make sure node and value, if either are lists, are of compatible size
         if isinstance(node, (list, np.ndarray)):
             if not isinstance(value, (list, np.ndarray)) or len(value) != len(node):

--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -2141,6 +2141,35 @@ class Labels(MutableSequence):
 
         return tracks
 
+    def merge_nodes(self, base_node: str, merge_node: str):
+        """Merge two nodes and update data accordingly.
+
+        Args:
+            base_node: Name of skeleton node that will remain after merging.
+            merge_node: Name of skeleton node that will be merged into the base node.
+
+        Notes:
+            This method can be used to merge two nodes that might have been named
+            differently but that should be associated with the same node.
+
+            This is useful, for example, when merging a different set of labels where
+            a node was named differently.
+
+            If the `base_node` is visible and has data, it will not be updated.
+            Otherwise, it will be updated with the data from the `merge_node` on the
+            same instance.
+        """
+        # Update data on all instances.
+        for inst in self.instances():
+            inst._merge_nodes_data(base_node, merge_node)
+
+        # Remove merge node from skeleton.
+        self.skeleton.delete_node(merge_node)
+
+        # Fix instances.
+        for inst in self.instances():
+            inst._fix_array()
+
     @classmethod
     def make_gui_video_callback(cls, search_paths: Optional[List] = None) -> Callable:
         return cls.make_video_callback(search_paths=search_paths, use_gui=True)

--- a/sleap/io/format/labels_json.py
+++ b/sleap/io/format/labels_json.py
@@ -408,7 +408,7 @@ class LabelsJsonAdaptor(Adaptor):
                             # use skeleton from match
                             skeletons[idx] = old_sk
                             break
-            else:
+            elif len(skeletons) == 1 and len(match_to.skeletons) == 1:
                 # Match by node names
                 old_skel = match_to.skeleton
                 new_skel = skeletons[0]

--- a/sleap/io/format/labels_json.py
+++ b/sleap/io/format/labels_json.py
@@ -396,16 +396,33 @@ class LabelsJsonAdaptor(Adaptor):
 
         # if we're given a Labels object to match, use its objects when they match
         if match_to is not None:
-            for idx, sk in enumerate(skeletons):
-                for old_sk in match_to.skeletons:
-                    if sk.matches(old_sk):
-                        # use nodes from matched skeleton
-                        for (node, match_node) in zip(sk.nodes, old_sk.nodes):
-                            node_idx = nodes.index(node)
-                            nodes[node_idx] = match_node
-                        # use skeleton from match
-                        skeletons[idx] = old_sk
-                        break
+            if len(skeletons) > 1 or len(match_to.skeletons) > 1:
+                # Match full skeletons
+                for idx, sk in enumerate(skeletons):
+                    for old_sk in match_to.skeletons:
+                        if sk.matches(old_sk):
+                            # use nodes from matched skeleton
+                            for (node, match_node) in zip(sk.nodes, old_sk.nodes):
+                                node_idx = nodes.index(node)
+                                nodes[node_idx] = match_node
+                            # use skeleton from match
+                            skeletons[idx] = old_sk
+                            break
+            else:
+                # Match by node names
+                old_skel = match_to.skeleton
+                new_skel = skeletons[0]
+
+                old_node_names = old_skel.node_names
+                for i, node in enumerate(nodes):
+                    if node.name in old_node_names:
+                        nodes[i] = old_skel.nodes[old_node_names.index(node.name)]
+                    else:
+                        old_skel._graph.add_node(node)
+
+                skeletons[0] = old_skel
+
+            # Match videos
             for idx, vid in enumerate(videos):
                 for old_vid in match_to.videos:
 

--- a/sleap/io/video.py
+++ b/sleap/io/video.py
@@ -976,7 +976,9 @@ class Video:
         return self.frames - 1
 
     @property
-    def shape(self) -> Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]:
+    def shape(
+        self,
+    ) -> Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]:
         """Return tuple of (frame count, height, width, channels)."""
         try:
             return (self.frames, self.height, self.width, self.channels)

--- a/sleap/io/video.py
+++ b/sleap/io/video.py
@@ -976,9 +976,12 @@ class Video:
         return self.frames - 1
 
     @property
-    def shape(self) -> Tuple[int, int, int, int]:
+    def shape(self) -> Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]:
         """Return tuple of (frame count, height, width, channels)."""
-        return (self.frames, self.height, self.width, self.channels)
+        try:
+            return (self.frames, self.height, self.width, self.channels)
+        except:
+            return (None, None, None, None)
 
     def __str__(self) -> str:
         """Informal string representation (for print or format)."""

--- a/tests/gui/test_merge.py
+++ b/tests/gui/test_merge.py
@@ -2,4 +2,4 @@ from sleap.gui.dialogs.merge import show_instance_type_counts
 
 
 def test_count_string(simple_predictions):
-    assert show_instance_type_counts(simple_predictions[0]) == "0/2"
+    assert show_instance_type_counts(simple_predictions[0]) == "0 (user) / 2 (pred)"

--- a/tests/io/test_dataset.py
+++ b/tests/io/test_dataset.py
@@ -1351,3 +1351,26 @@ def test_remove_empty_instances_and_frames(min_labels):
             pt.visible = False
     min_labels.remove_empty_instances(keep_empty_frames=False)
     assert len(min_labels) == 0
+
+
+def test_merge_nodes(min_labels):
+    labels = min_labels.copy()
+    labels.skeleton.add_node("a")
+
+    inst = labels[0][0]
+    inst["A"] = Point(x=np.nan, y=np.nan, visible=False)
+    inst["a"] = Point(x=1, y=2, visible=True)
+    inst = labels[0][1]
+    inst["A"] = Point(x=0, y=1, visible=False)
+    inst["a"] = Point(x=1, y=2, visible=True)
+    
+    labels.merge_nodes("A", "a")
+
+    assert labels.skeleton.node_names == ["A", "B"]
+
+    inst = labels[0][0]
+    assert inst["A"].x == 1 and inst["A"].y == 2
+    assert len(inst.nodes) == 2
+    inst = labels[0][1]
+    assert inst["A"].x == 1 and inst["A"].y == 2
+    assert len(inst.nodes) == 2

--- a/tests/io/test_dataset.py
+++ b/tests/io/test_dataset.py
@@ -597,7 +597,6 @@ def test_merge_with_skeleton_conflict(min_labels, tmpdir):
     labels[0].frame_idx = 1
     labels.skeleton.add_node("C")
     inst = labels[0][0]
-    inst._fix_array()
     inst["C"] = sleap.instance.Point(x=1, y=2, visible=True)
     labels.save(f"{tmpdir}/labels.new_node.slp")
 

--- a/tests/io/test_dataset.py
+++ b/tests/io/test_dataset.py
@@ -1363,7 +1363,7 @@ def test_merge_nodes(min_labels):
     inst = labels[0][1]
     inst["A"] = Point(x=0, y=1, visible=False)
     inst["a"] = Point(x=1, y=2, visible=True)
-    
+
     labels.merge_nodes("A", "a")
 
     assert labels.skeleton.node_names == ["A", "B"]

--- a/tests/io/test_dataset.py
+++ b/tests/io/test_dataset.py
@@ -571,6 +571,64 @@ def test_merge_with_package(min_labels_robot, tmpdir):
     assert labels_pkg.predicted_instances[0].frame.frame_idx == 1
 
 
+def test_merge_with_skeleton_conflict(min_labels, tmpdir):
+    # Save out base labels
+    base_labels = min_labels.copy()
+    base_labels.save(f"{tmpdir}/base_labels.slp")
+
+    # Merge labels with a renamed node
+    labels = base_labels.copy()
+    labels[0].frame_idx = 1
+    labels.skeleton.relabel_node("A", "a")
+    labels.save(f"{tmpdir}/labels.renamed_node.slp")
+
+    labels = base_labels.copy()
+    merged, extra_base, extra_new = sleap.Labels.complex_merge_between(
+        labels, sleap.load_file(f"{tmpdir}/labels.renamed_node.slp")
+    )
+    assert len(extra_base) == 0
+    assert len(extra_new) == 0
+    assert labels.skeleton.node_names == ["A", "B", "a"]
+    assert np.isnan(labels[0][0].numpy()).any(axis=1).tolist() == [False, False, True]
+    assert np.isnan(labels[1][0].numpy()).any(axis=1).tolist() == [True, False, False]
+
+    # Merge labels with a new node
+    labels = base_labels.copy()
+    labels[0].frame_idx = 1
+    labels.skeleton.add_node("C")
+    inst = labels[0][0]
+    inst._fix_array()
+    inst["C"] = sleap.instance.Point(x=1, y=2, visible=True)
+    labels.save(f"{tmpdir}/labels.new_node.slp")
+
+    labels = base_labels.copy()
+    merged, extra_base, extra_new = sleap.Labels.complex_merge_between(
+        labels, sleap.load_file(f"{tmpdir}/labels.new_node.slp")
+    )
+    assert len(extra_base) == 0
+    assert len(extra_new) == 0
+    assert labels.skeleton.node_names == ["A", "B", "C"]
+    assert np.isnan(labels[0][0].numpy()).any(axis=1).tolist() == [False, False, True]
+    assert np.isnan(labels[1][0].numpy()).any(axis=1).tolist() == [False, False, False]
+
+    # Merge labels with a deleted node
+    labels = base_labels.copy()
+    labels[0].frame_idx = 1
+    labels.skeleton.delete_node("A")
+    labels.save(f"{tmpdir}/labels.deleted_node.slp")
+
+    labels = base_labels.copy()
+    merged, extra_base, extra_new = sleap.Labels.complex_merge_between(
+        labels, sleap.load_file(f"{tmpdir}/labels.deleted_node.slp")
+    )
+    assert len(extra_base) == 0
+    assert len(extra_new) == 0
+    assert labels.skeleton.node_names == ["A", "B"]
+    assert np.isnan(labels[0][0].numpy()).any(axis=1).tolist() == [False, False]
+    assert np.isnan(labels[1][0].numpy()).any(axis=1).tolist() == [True, False]
+    assert (labels[0][0].numpy()[1] == labels[1][0].numpy()[1]).all()
+
+
 def skeleton_ids_from_label_instances(labels):
     return list(map(id, (lf.instances[0].skeleton for lf in labels.labeled_frames)))
 

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -158,7 +158,7 @@ def test_instance_comparison(skeleton):
 
 
 def test_points_array(skeleton):
-    """ Test conversion of instances to points array"""
+    """Test conversion of instances to points array"""
 
     node_names = ["left-wing", "head", "right-wing"]
     points = {"head": Point(1, 4), "left-wing": Point(2, 5), "right-wing": Point(3, 6)}
@@ -388,7 +388,7 @@ def test_merge_nodes_data(min_labels):
     inst["a"] = Point(x=1, y=2, visible=True)
     inst._merge_nodes_data("A", "a")
     assert inst["A"].x == 0 and inst["A"].y == 1
-    
+
     # case: base node point unset
     inst = labels[0][0]
     inst["A"] = Point(x=np.nan, y=np.nan, visible=False)

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -403,3 +403,11 @@ def test_merge_nodes_data(min_labels):
     inst._merge_nodes_data("A", "a")
     assert inst["A"].x == 1 and inst["A"].y == 2
 
+    inst = PredictedInstance.from_numpy(
+        points=np.array([[np.nan, np.nan], [1, 2], [2, 3]]),
+        point_confidences=np.array([0.1, 0.8, 0.9]),
+        instance_score=0.7,
+        skeleton=labels.skeleton,
+    )
+    inst._merge_nodes_data("A", "a")
+    assert inst["A"].x == 2 and inst["A"].y == 3 and inst["A"].score == 0.9

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -403,6 +403,7 @@ def test_merge_nodes_data(min_labels):
     inst._merge_nodes_data("A", "a")
     assert inst["A"].x == 1 and inst["A"].y == 2
 
+    # case: predicted instance/point
     inst = PredictedInstance.from_numpy(
         points=np.array([[np.nan, np.nan], [1, 2], [2, 3]]),
         point_confidences=np.array([0.1, 0.8, 0.9]),

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -376,3 +376,30 @@ def test_instance_rotation(skeleton):
 
     assert int(instance["head"].x) == 45
     assert int(instance["head"].y) == 31
+
+
+def test_merge_nodes_data(min_labels):
+    labels = min_labels.copy()
+    labels.skeleton.add_node("a")
+
+    # case: base node point set and visible
+    inst = labels[0][0]
+    inst["A"] = Point(x=0, y=1, visible=True)
+    inst["a"] = Point(x=1, y=2, visible=True)
+    inst._merge_nodes_data("A", "a")
+    assert inst["A"].x == 0 and inst["A"].y == 1
+    
+    # case: base node point unset
+    inst = labels[0][0]
+    inst["A"] = Point(x=np.nan, y=np.nan, visible=False)
+    inst["a"] = Point(x=1, y=2, visible=True)
+    inst._merge_nodes_data("A", "a")
+    assert inst["A"].x == 1 and inst["A"].y == 2
+
+    # case: base node point set but not visible
+    inst = labels[0][1]
+    inst["A"] = Point(x=0, y=1, visible=False)
+    inst["a"] = Point(x=1, y=2, visible=True)
+    inst._merge_nodes_data("A", "a")
+    assert inst["A"].x == 1 and inst["A"].y == 2
+


### PR DESCRIPTION
### Description
This PR implements functionality to deal with **skeleton** merge conflicts.

Use case: merging in labels with different number or names of nodes.

- Fix: When merging, union of nodes is now used instead of adding multiple skeletons if node names aren't identical.
- Feature: Add warning message in merge dialog if nodes are not matching.
- Feature: Add `Labels.merge_nodes()` method to support merging one node into another with data update. This is equivalent to `Skeleton.relabel_nodes()` but takes care of updating the point data for the base node.
- Feature: Enable node merging when renaming nodes from skeleton editor.

### Types of changes

- [x] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
N/A

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/murthylab/sleap/wiki/Developer-Guide) to this repository
- [ ] Read and sign the [CLA](https://github.com/murthylab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/murthylab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
