### PR TITLE
Fix path resolution in training & inference

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1588,6 +1588,7 @@ class MainWindow(QMainWindow):
             return
 
         if self._child_windows.get(mode, None) is None:
+            # Re-use existing dialog widget.
             self._child_windows[mode] = LearningDialog(
                 mode,
                 self.state["filename"],
@@ -1596,6 +1597,11 @@ class MainWindow(QMainWindow):
             self._child_windows[mode]._handle_learning_finished.connect(
                 self._handle_learning_finished
             )
+        else:
+            # Update data in existing dialog widget.
+            self._child_windows[mode].labels = self.labels
+            self._child_windows[mode].labels_filename = self.state["filename"]
+            self._child_windows[mode].skeleton = self.labels.skeleton
 
         self._child_windows[mode].update_file_lists()
 

--- a/sleap/nn/data/providers.py
+++ b/sleap/nn/data/providers.py
@@ -87,7 +87,7 @@ class LabelsReader:
         Returns:
             A `LabelsReader` instance that can create a dataset for pipelining.
         """
-        labels = sleap.Labels.load_file(filename)
+        labels = sleap.load_file(filename)
         if user_instances:
             return cls.from_user_instances(labels)
         else:

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -2947,7 +2947,7 @@ def _make_provider_from_cli(args: argparse.Namespace) -> Tuple[Provider, str]:
         )
 
     if data_path.endswith(".slp"):
-        labels = sleap.Labels.load_file(data_path)
+        labels = sleap.load_file(data_path)
 
         if args.only_labeled_frames:
             provider = LabelsReader.from_user_labeled_frames(labels)

--- a/sleap/nn/training.py
+++ b/sleap/nn/training.py
@@ -157,7 +157,7 @@ class DataReaders:
         """Create data readers from sleap.Labels datasets as data providers."""
         if isinstance(training, str):
             logger.info(f"Loading training labels from: {training}")
-            training = sleap.Labels.load_file(training, video_search=video_search_paths)
+            training = sleap.load_file(training, video_search=video_search_paths)
 
         if labels_config is not None and labels_config.split_by_inds:
             # First try to split by indices if specified in config.
@@ -192,7 +192,7 @@ class DataReaders:
             # If validation is still a path, load it.
             logger.info(f"Loading validation labels from: {validation}")
             validation = sleap.Labels.load_file(
-                validation, video_search=video_search_paths
+                validation, search_paths=video_search_paths
             )
         elif isinstance(validation, float):
             logger.info(
@@ -217,7 +217,7 @@ class DataReaders:
         if isinstance(test, str):
             # If test is still a path, load it.
             logger.info(f"Loading test labels from: {test}")
-            test = sleap.Labels.load_file(test, video_search=video_search_paths)
+            test = sleap.load_file(test, search_paths=video_search_paths)
 
         test_reader = None
         if test is not None:

--- a/sleap/nn/training.py
+++ b/sleap/nn/training.py
@@ -1568,6 +1568,9 @@ def main():
     job_config.outputs.save_visualizations |= args.save_viz
     if args.labels_path == "":
         args.labels_path = None
+    args.video_paths = args.video_paths.split(",")
+    if len(args.video_paths) == 0:
+        args.video_paths = None
 
     logger.info("Versions:")
     sleap.versions()
@@ -1613,7 +1616,7 @@ def main():
         training_labels=args.labels_path,
         validation_labels=args.val_labels,
         test_labels=args.test_labels,
-        video_search_paths=args.video_paths.split(","),
+        video_search_paths=args.video_paths,
     )
     trainer.train()
 


### PR DESCRIPTION
### Description
- Update labels and filename when opening new `LearningDialog`s (should fix #634)
- Unify video loading calls so we use `sleap.load_file` (and its path resolution) everywhere (hotfix for #644)

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/murthylab/sleap/wiki/Developer-Guide) to this repository
- [ ] Read and sign the [CLA](https://github.com/murthylab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/murthylab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
