### PR TITLE
Make PAF distance penalty more usable

### DIFF
--- a/sleap/nn/paf_grouping.py
+++ b/sleap/nn/paf_grouping.py
@@ -515,7 +515,11 @@ def score_paf_lines_batch(
             pafs_stride,
         )
         line_scores_sample = score_paf_lines(
-            paf_lines_sample, peaks_sample, edge_peak_inds_sample, max_edge_length, dist_penalty_weight=dist_penalty_weight
+            paf_lines_sample,
+            peaks_sample,
+            edge_peak_inds_sample,
+            max_edge_length,
+            dist_penalty_weight=dist_penalty_weight,
         )
         n_candidates = tf.shape(edge_peak_inds_sample)[0]
 


### PR DESCRIPTION
### Description
The PAF distance penalty can be quite useful for getting rid of spurious connections that are too long to be correct. Here we expose the penalty to the `sleap-track` CLI and add a scaling factor to enforce it more strictly:

```
  --max_edge_length_ratio MAX_EDGE_LENGTH_RATIO
                        The maximum expected length of a connected pair of
                        points as a fraction of the image size. Candidate
                        connections longer than this length will be penalized
                        during matching. Only applies to bottom-up (PAF)
                        models.
  --dist_penalty_weight DIST_PENALTY_WEIGHT
                        A coefficient to scale weight of the distance penalty.
                        Set to values greater than 1.0 to enforce the distance
                        penalty more strictly. Only applies to bottom-up (PAF)
                        models.
```


### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/murthylab/sleap/wiki/Developer-Guide) to this repository
- [ ] Read and sign the [CLA](https://github.com/murthylab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/murthylab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
