### PR TITLE
Fix numpy conversion in inference

### DIFF
--- a/sleap/nn/__init__.py
+++ b/sleap/nn/__init__.py
@@ -13,3 +13,4 @@ import sleap.nn.system
 import sleap.nn.training
 import sleap.nn.tracking
 import sleap.nn.viz
+import sleap.nn.identity

--- a/tests/nn/test_inference.py
+++ b/tests/nn/test_inference.py
@@ -715,3 +715,76 @@ def test_load_model(
 
     predictor = load_model(min_bottomup_multiclass_model_path)
     assert isinstance(predictor, BottomUpMultiClassPredictor)
+
+
+def test_ensure_numpy(
+    min_centroid_model_path, min_centered_instance_model_path, min_labels_slp
+):
+
+    model = load_model([min_centroid_model_path, min_centered_instance_model_path])
+
+    # each frame has same number of instances
+    same_shape = min_labels_slp.video[:4]
+
+    out = model.inference_model.predict(same_shape, numpy=False)
+
+    assert type(out["instance_peaks"]) == tf.RaggedTensor
+    assert type(out["instance_peak_vals"]) == tf.RaggedTensor
+    assert type(out["centroids"]) == tf.RaggedTensor
+    assert type(out["centroid_vals"]) == tf.RaggedTensor
+
+    out = model.inference_model.predict(same_shape, numpy=True)
+
+    assert type(out["instance_peaks"]) == np.ndarray
+    assert type(out["instance_peak_vals"]) == np.ndarray
+    assert type(out["centroids"]) == np.ndarray
+    assert type(out["centroid_vals"]) == np.ndarray
+    assert type(out["n_valid"]) == np.ndarray
+
+    out = model.inference_model.predict_on_batch(same_shape, numpy=False)
+
+    assert type(out["instance_peaks"]) == tf.RaggedTensor
+    assert type(out["instance_peak_vals"]) == tf.RaggedTensor
+    assert type(out["centroids"]) == tf.RaggedTensor
+    assert type(out["centroid_vals"]) == tf.RaggedTensor
+
+    out = model.inference_model.predict_on_batch(same_shape, numpy=True)
+
+    assert type(out["instance_peaks"]) == np.ndarray
+    assert type(out["instance_peak_vals"]) == np.ndarray
+    assert type(out["centroids"]) == np.ndarray
+    assert type(out["centroid_vals"]) == np.ndarray
+    assert type(out["n_valid"]) == np.ndarray
+
+    # variable number of instances
+    diff_shape = min_labels_slp.video[4:8]
+
+    out = model.inference_model.predict(diff_shape, numpy=False)
+
+    assert type(out["instance_peaks"]) == tf.RaggedTensor
+    assert type(out["instance_peak_vals"]) == tf.RaggedTensor
+    assert type(out["centroids"]) == tf.RaggedTensor
+    assert type(out["centroid_vals"]) == tf.RaggedTensor
+
+    out = model.inference_model.predict(diff_shape, numpy=True)
+
+    assert type(out["instance_peaks"]) == np.ndarray
+    assert type(out["instance_peak_vals"]) == np.ndarray
+    assert type(out["centroids"]) == np.ndarray
+    assert type(out["centroid_vals"]) == np.ndarray
+    assert type(out["n_valid"]) == np.ndarray
+
+    out = model.inference_model.predict_on_batch(diff_shape, numpy=False)
+
+    assert type(out["instance_peaks"]) == tf.RaggedTensor
+    assert type(out["instance_peak_vals"]) == tf.RaggedTensor
+    assert type(out["centroids"]) == tf.RaggedTensor
+    assert type(out["centroid_vals"]) == tf.RaggedTensor
+
+    out = model.inference_model.predict_on_batch(diff_shape, numpy=True)
+
+    assert type(out["instance_peaks"]) == np.ndarray
+    assert type(out["instance_peak_vals"]) == np.ndarray
+    assert type(out["centroids"]) == np.ndarray
+    assert type(out["centroid_vals"]) == np.ndarray
+    assert type(out["n_valid"]) == np.ndarray


### PR DESCRIPTION
### Description

- Expose identity module in nn __init__ file that was causing import issues
- Optionally cast data to numpy in predict_on_batch which fixes prediction bottleneck

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/murthylab/sleap/wiki/Developer-Guide) to this repository
- [ ] Read and sign the [CLA](https://github.com/murthylab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/murthylab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
